### PR TITLE
Remove redundant method modifiers

### DIFF
--- a/src/main/java/de/upb/soot/core/IField.java
+++ b/src/main/java/de/upb/soot/core/IField.java
@@ -9,5 +9,5 @@ import de.upb.soot.signatures.ISignature;
  *
  */
 public interface IField {
-  public ISignature getSignature();
+  ISignature getSignature();
 }

--- a/src/main/java/de/upb/soot/core/IMethod.java
+++ b/src/main/java/de/upb/soot/core/IMethod.java
@@ -9,5 +9,5 @@ import de.upb.soot.signatures.ISignature;
  *
  */
 public interface IMethod {
-  public ISignature getSignature();
+  ISignature getSignature();
 }

--- a/src/main/java/de/upb/soot/graph/DirectedGraph.java
+++ b/src/main/java/de/upb/soot/graph/DirectedGraph.java
@@ -36,29 +36,28 @@ public interface DirectedGraph<N> extends Iterable<N> {
   /**
    * Returns a list of entry points for this graph.
    */
-  public List<N> getHeads();
+  List<N> getHeads();
 
   /** Returns a list of exit points for this graph. */
-  public List<N> getTails();
+  List<N> getTails();
 
   /**
    * Returns a list of predecessors for the given node in the graph.
    */
-  public List<N> getPredsOf(N s);
+  List<N> getPredsOf(N s);
 
   /**
    * Returns a list of successors for the given node in the graph.
    */
-  public List<N> getSuccsOf(N s);
+  List<N> getSuccsOf(N s);
 
   /**
    * Returns the node count for this graph.
    */
-  public int size();
+  int size();
 
   /**
    * Returns an iterator for the nodes in this graph. No specific ordering of the nodes is guaranteed.
    */
-  @Override
-  public Iterator<N> iterator();
+  @Override Iterator<N> iterator();
 }

--- a/src/main/java/de/upb/soot/jimple/basic/EqualLocals.java
+++ b/src/main/java/de/upb/soot/jimple/basic/EqualLocals.java
@@ -30,8 +30,8 @@ import de.upb.soot.jimple.common.stmt.IStmt;
 import java.util.List;
 
 public interface EqualLocals {
-  public boolean isLocalEqualToAt(Local l1, Local l2, IStmt s);
+  boolean isLocalEqualToAt(Local l1, Local l2, IStmt s);
 
-  public List getCopiesAt(IStmt s);
+  List getCopiesAt(IStmt s);
 
 }

--- a/src/main/java/de/upb/soot/jimple/basic/EquivTo.java
+++ b/src/main/java/de/upb/soot/jimple/basic/EquivTo.java
@@ -36,13 +36,13 @@ public interface EquivTo {
   /**
    * Returns true if this object is equivalent to o.
    */
-  public boolean equivTo(Object o);
+  boolean equivTo(Object o);
 
   /**
    * Returns a (not necessarily fixed) hash code for this object. This hash code coincides with equivTo; it is undefined in
    * the presence of mutable objects.
    */
-  public int equivHashCode();
+  int equivHashCode();
 
   /**
    * Returns true if this object is equivalent to o according to the given comparator.
@@ -51,5 +51,5 @@ public interface EquivTo {
    * @param comparator
    * @return
    */
-  public boolean equivTo(Object o, Comparator<? extends Object> comparator);
+  boolean equivTo(Object o, Comparator<? extends Object> comparator);
 }

--- a/src/main/java/de/upb/soot/jimple/basic/IStmtBox.java
+++ b/src/main/java/de/upb/soot/jimple/basic/IStmtBox.java
@@ -35,10 +35,10 @@ import java.io.Serializable;
 
 public interface IStmtBox extends Serializable {
   /** Sets this box to contain the given unit. Subject to canContainValue() checks. */
-  public void setStmt(IStmt u);
+  void setStmt(IStmt u);
 
   /** Returns the unit contained within this box. */
-  public IStmt getStmt();
+  IStmt getStmt();
   /**
    * Returns true if the StmtBox is holding a Stmt that is the target of a branch (ie a Stmt at the beginning of a CFG
    * block). This is the default case.
@@ -48,7 +48,7 @@ public interface IStmtBox extends Serializable {
    * processing for SSA.
    * </p>
    **/
-  public boolean isBranchTarget();
+  boolean isBranchTarget();
 
-  public void toString(IStmtPrinter up);
+  void toString(IStmtPrinter up);
 }

--- a/src/main/java/de/upb/soot/jimple/basic/StmtBoxOwner.java
+++ b/src/main/java/de/upb/soot/jimple/basic/StmtBoxOwner.java
@@ -35,7 +35,7 @@ import java.util.List;
  **/
 public interface StmtBoxOwner {
 
-  public List<IStmtBox> getStmtBoxes();
+  List<IStmtBox> getStmtBoxes();
 
-  public void clearStmtBoxes();
+  void clearStmtBoxes();
 }

--- a/src/main/java/de/upb/soot/jimple/basic/Trap.java
+++ b/src/main/java/de/upb/soot/jimple/basic/Trap.java
@@ -12,14 +12,14 @@ import de.upb.soot.jimple.common.stmt.IStmt;
 public interface Trap extends StmtBoxOwner {
 
   /** Performs a shallow clone of this trap. */
-  public Object clone();
+  Object clone();
 
-  public SootClass getException();
+  SootClass getException();
 
-  public IStmt getBeginStmt();
+  IStmt getBeginStmt();
 
-  public IStmt getEndStmt();
+  IStmt getEndStmt();
 
-  public IStmt getHandlerStmt();
+  IStmt getHandlerStmt();
 
 }

--- a/src/main/java/de/upb/soot/jimple/basic/Value.java
+++ b/src/main/java/de/upb/soot/jimple/basic/Value.java
@@ -42,13 +42,13 @@ public interface Value extends IAcceptor, EquivTo, Serializable {
   /**
    * Returns a List of boxes corresponding to Values which are used by (ie contained within) this Value.
    */
-  public List<ValueBox> getUseBoxes();
+  List<ValueBox> getUseBoxes();
 
   /** Returns the Soot type of this Value. */
-  public Type getType();
+  Type getType();
 
   /** Returns a clone of this Value. */
-  public Object clone();
+  Object clone();
 
-  public void toString(IStmtPrinter up);
+  void toString(IStmtPrinter up);
 }

--- a/src/main/java/de/upb/soot/jimple/basic/ValueBox.java
+++ b/src/main/java/de/upb/soot/jimple/basic/ValueBox.java
@@ -36,14 +36,14 @@ import java.io.Serializable;
  */
 public interface ValueBox extends Serializable {
   /** Sets the value contained in this box as given. Subject to canContainValue() checks. */
-  public void setValue(Value value);
+  void setValue(Value value);
 
   /** Returns the value contained in this box. */
-  public Value getValue();
+  Value getValue();
 
   /** Returns true if the given Value fits in this box. */
-  public boolean canContainValue(Value value);
+  boolean canContainValue(Value value);
 
-  public void toString(IStmtPrinter up);
+  void toString(IStmtPrinter up);
 
 }

--- a/src/main/java/de/upb/soot/jimple/common/ref/FieldRef.java
+++ b/src/main/java/de/upb/soot/jimple/common/ref/FieldRef.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 
 public interface FieldRef extends ConcreteRef {
 
-  public Optional<SootField> getField();
-  public FieldSignature getFieldSignature();
+  Optional<SootField> getField();
+  FieldSignature getFieldSignature();
 
 }

--- a/src/main/java/de/upb/soot/jimple/common/stmt/IStmt.java
+++ b/src/main/java/de/upb/soot/jimple/common/stmt/IStmt.java
@@ -16,72 +16,72 @@ import java.util.List;
 
 public interface IStmt extends EquivTo, IAcceptor, Serializable {
   /** Returns a list of Boxes containing Values used in this Stmt. */
-  public List<ValueBox> getUseBoxes();
+  List<ValueBox> getUseBoxes();
 
   /** Returns a list of Boxes containing Values defined in this Stmt. */
-  public List<ValueBox> getDefBoxes();
+  List<ValueBox> getDefBoxes();
 
   /**
    * Returns a list of Boxes containing Stmts defined in this Stmt; typically branch targets.
    */
-  public List<IStmtBox> getStmtBoxes();
+  List<IStmtBox> getStmtBoxes();
 
   /** Returns a list of Boxes pointing to this Stmt. */
-  public List<IStmtBox> getBoxesPointingToThis();
+  List<IStmtBox> getBoxesPointingToThis();
 
   /** Adds a box to the list returned by getBoxesPointingToThis. */
-  public void addBoxPointingToThis(IStmtBox b);
+  void addBoxPointingToThis(IStmtBox b);
 
   /** Removes a box from the list returned by getBoxesPointingToThis. */
-  public void removeBoxPointingToThis(IStmtBox b);
+  void removeBoxPointingToThis(IStmtBox b);
 
   /** Clears any pointers to and from this Stmt's StmtBoxes. */
-  public void clearStmtBoxes();
+  void clearStmtBoxes();
 
   /**
    * Returns a list of Boxes containing any Value either used or defined in this Stmt.
    */
-  public List<ValueBox> getUseAndDefBoxes();
+  List<ValueBox> getUseAndDefBoxes();
 
-  public IStmt clone();
+  IStmt clone();
 
   /**
    * Returns true if execution after this statement may continue at the following statement. GotoStmt will return false but
    * IfStmt will return true.
    */
-  public boolean fallsThrough();
+  boolean fallsThrough();
 
   /**
    * Returns true if execution after this statement does not necessarily continue at the following statement. GotoStmt and
    * IfStmt will both return true.
    */
-  public boolean branches();
+  boolean branches();
 
   /**
    * Redirects jumps to this Stmt to newLocation. In general, you shouldn't have to use this directly.
    *
    **/
-  public void redirectJumpsToThisTo(IStmt newLocation);
+  void redirectJumpsToThisTo(IStmt newLocation);
 
-  public void toString(IStmtPrinter up);
+  void toString(IStmtPrinter up);
 
-  public boolean containsInvokeExpr();
+  boolean containsInvokeExpr();
 
-  public AbstractInvokeExpr getInvokeExpr();
+  AbstractInvokeExpr getInvokeExpr();
 
-  public ValueBox getInvokeExprBox();
+  ValueBox getInvokeExprBox();
 
-  public boolean containsArrayRef();
+  boolean containsArrayRef();
 
-  public JArrayRef getArrayRef();
+  JArrayRef getArrayRef();
 
-  public ValueBox getArrayRefBox();
+  ValueBox getArrayRefBox();
 
-  public boolean containsFieldRef();
+  boolean containsFieldRef();
 
-  public FieldRef getFieldRef();
+  FieldRef getFieldRef();
 
-  public ValueBox getFieldRefBox();
+  ValueBox getFieldRefBox();
 
-  public void setPosition(Position position);
+  void setPosition(Position position);
 }

--- a/src/main/java/de/upb/soot/jimple/visitor/IAcceptor.java
+++ b/src/main/java/de/upb/soot/jimple/visitor/IAcceptor.java
@@ -28,5 +28,5 @@ package de.upb.soot.jimple.visitor;
 /** Basic interface used for visited objects in the Visitor design pattern. */
 public interface IAcceptor {
   /** Called when this object is visited. */
-  public void accept(IVisitor v);
+  void accept(IVisitor v);
 }

--- a/src/main/java/de/upb/soot/jimple/visitor/IConstantVisitor.java
+++ b/src/main/java/de/upb/soot/jimple/visitor/IConstantVisitor.java
@@ -35,21 +35,21 @@ import de.upb.soot.jimple.common.constant.NullConstant;
 import de.upb.soot.jimple.common.constant.StringConstant;
 
 public interface IConstantVisitor extends IVisitor {
-  public abstract void caseDoubleConstant(DoubleConstant v);
+  void caseDoubleConstant(DoubleConstant v);
 
-  public abstract void caseFloatConstant(FloatConstant v);
+  void caseFloatConstant(FloatConstant v);
 
-  public abstract void caseIntConstant(IntConstant v);
+  void caseIntConstant(IntConstant v);
 
-  public abstract void caseLongConstant(LongConstant v);
+  void caseLongConstant(LongConstant v);
 
-  public abstract void caseNullConstant(NullConstant v);
+  void caseNullConstant(NullConstant v);
 
-  public abstract void caseStringConstant(StringConstant v);
+  void caseStringConstant(StringConstant v);
 
-  public abstract void caseClassConstant(ClassConstant v);
+  void caseClassConstant(ClassConstant v);
 
-  public abstract void caseMethodHandle(MethodHandle handle);
+  void caseMethodHandle(MethodHandle handle);
 
-  public abstract void defaultCase(Object object);
+  void defaultCase(Object object);
 }

--- a/src/main/java/de/upb/soot/jimple/visitor/IExprVisitor.java
+++ b/src/main/java/de/upb/soot/jimple/visitor/IExprVisitor.java
@@ -57,65 +57,65 @@ import de.upb.soot.jimple.common.expr.JUshrExpr;
 import de.upb.soot.jimple.common.expr.JXorExpr;
 
 public interface IExprVisitor extends IVisitor {
-  public abstract void caseAddExpr(JAddExpr v);
+  void caseAddExpr(JAddExpr v);
 
-  public abstract void caseAndExpr(JAndExpr v);
+  void caseAndExpr(JAndExpr v);
 
-  public abstract void caseCmpExpr(JCmpExpr v);
+  void caseCmpExpr(JCmpExpr v);
 
-  public abstract void caseCmpgExpr(JCmpgExpr v);
+  void caseCmpgExpr(JCmpgExpr v);
 
-  public abstract void caseCmplExpr(JCmplExpr v);
+  void caseCmplExpr(JCmplExpr v);
 
-  public abstract void caseDivExpr(JDivExpr v);
+  void caseDivExpr(JDivExpr v);
 
-  public abstract void caseEqExpr(JEqExpr v);
+  void caseEqExpr(JEqExpr v);
 
-  public abstract void caseNeExpr(JNeExpr v);
+  void caseNeExpr(JNeExpr v);
 
-  public abstract void caseGeExpr(JGeExpr v);
+  void caseGeExpr(JGeExpr v);
 
-  public abstract void caseGtExpr(JGtExpr v);
+  void caseGtExpr(JGtExpr v);
 
-  public abstract void caseLeExpr(JLeExpr v);
+  void caseLeExpr(JLeExpr v);
 
-  public abstract void caseLtExpr(JLtExpr v);
+  void caseLtExpr(JLtExpr v);
 
-  public abstract void caseMulExpr(JMulExpr v);
+  void caseMulExpr(JMulExpr v);
 
-  public abstract void caseOrExpr(JOrExpr v);
+  void caseOrExpr(JOrExpr v);
 
-  public abstract void caseRemExpr(JRemExpr v);
+  void caseRemExpr(JRemExpr v);
 
-  public abstract void caseShlExpr(JShlExpr v);
+  void caseShlExpr(JShlExpr v);
 
-  public abstract void caseShrExpr(JShrExpr v);
+  void caseShrExpr(JShrExpr v);
 
-  public abstract void caseUshrExpr(JUshrExpr v);
+  void caseUshrExpr(JUshrExpr v);
 
-  public abstract void caseSubExpr(JSubExpr v);
+  void caseSubExpr(JSubExpr v);
 
-  public abstract void caseXorExpr(JXorExpr v);
+  void caseXorExpr(JXorExpr v);
 
-  public abstract void caseInstanceInvokeExpr(AbstractInstanceInvokeExpr v);
+  void caseInstanceInvokeExpr(AbstractInstanceInvokeExpr v);
 
-  public abstract void caseStaticInvokeExpr(JStaticInvokeExpr v);
+  void caseStaticInvokeExpr(JStaticInvokeExpr v);
 
-  public abstract void caseDynamicInvokeExpr(JDynamicInvokeExpr v);
+  void caseDynamicInvokeExpr(JDynamicInvokeExpr v);
 
-  public abstract void caseCastExpr(JCastExpr v);
+  void caseCastExpr(JCastExpr v);
 
-  public abstract void caseInstanceOfExpr(JInstanceOfExpr v);
+  void caseInstanceOfExpr(JInstanceOfExpr v);
 
-  public abstract void caseNewArrayExpr(JNewArrayExpr v);
+  void caseNewArrayExpr(JNewArrayExpr v);
 
-  public abstract void caseNewMultiArrayExpr(JNewMultiArrayExpr v);
+  void caseNewMultiArrayExpr(JNewMultiArrayExpr v);
 
-  public abstract void caseNewExpr(JNewExpr v);
+  void caseNewExpr(JNewExpr v);
 
-  public abstract void caseLengthExpr(JLengthExpr v);
+  void caseLengthExpr(JLengthExpr v);
 
-  public abstract void caseNegExpr(JNegExpr v);
+  void caseNegExpr(JNegExpr v);
 
-  public abstract void defaultCase(Object obj);
+  void defaultCase(Object obj);
 }

--- a/src/main/java/de/upb/soot/jimple/visitor/IJimpleValueVisitor.java
+++ b/src/main/java/de/upb/soot/jimple/visitor/IJimpleValueVisitor.java
@@ -28,6 +28,6 @@ package de.upb.soot.jimple.visitor;
 import de.upb.soot.jimple.basic.Local;
 
 public interface IJimpleValueVisitor extends IConstantVisitor, IExprVisitor {
-  public abstract void caseLocal(Local jimpleLocal);
+  void caseLocal(Local jimpleLocal);
 
 }

--- a/src/main/java/de/upb/soot/jimple/visitor/IStmtVisitor.java
+++ b/src/main/java/de/upb/soot/jimple/visitor/IStmtVisitor.java
@@ -42,35 +42,35 @@ import de.upb.soot.jimple.javabytecode.stmt.JRetStmt;
 import de.upb.soot.jimple.javabytecode.stmt.JTableSwitchStmt;
 
 public interface IStmtVisitor extends IVisitor {
-  public abstract void caseBreakpointStmt(JBreakpointStmt stmt);
+  void caseBreakpointStmt(JBreakpointStmt stmt);
 
-  public abstract void caseInvokeStmt(JInvokeStmt stmt);
+  void caseInvokeStmt(JInvokeStmt stmt);
 
-  public abstract void caseAssignStmt(JAssignStmt stmt);
+  void caseAssignStmt(JAssignStmt stmt);
 
-  public abstract void caseIdentityStmt(JIdentityStmt stmt);
+  void caseIdentityStmt(JIdentityStmt stmt);
 
-  public abstract void caseEnterMonitorStmt(JEnterMonitorStmt stmt);
+  void caseEnterMonitorStmt(JEnterMonitorStmt stmt);
 
-  public abstract void caseExitMonitorStmt(JExitMonitorStmt stmt);
+  void caseExitMonitorStmt(JExitMonitorStmt stmt);
 
-  public abstract void caseGotoStmt(JGotoStmt stmt);
+  void caseGotoStmt(JGotoStmt stmt);
 
-  public abstract void caseIfStmt(JIfStmt stmt);
+  void caseIfStmt(JIfStmt stmt);
 
-  public abstract void caseLookupSwitchStmt(JLookupSwitchStmt stmt);
+  void caseLookupSwitchStmt(JLookupSwitchStmt stmt);
 
-  public abstract void caseNopStmt(JNopStmt stmt);
+  void caseNopStmt(JNopStmt stmt);
 
-  public abstract void caseRetStmt(JRetStmt stmt);
+  void caseRetStmt(JRetStmt stmt);
 
-  public abstract void caseReturnStmt(JReturnStmt stmt);
+  void caseReturnStmt(JReturnStmt stmt);
 
-  public abstract void caseReturnVoidStmt(JReturnVoidStmt stmt);
+  void caseReturnVoidStmt(JReturnVoidStmt stmt);
 
-  public abstract void caseTableSwitchStmt(JTableSwitchStmt stmt);
+  void caseTableSwitchStmt(JTableSwitchStmt stmt);
 
-  public abstract void caseThrowStmt(JThrowStmt stmt);
+  void caseThrowStmt(JThrowStmt stmt);
 
-  public abstract void defaultCase(Object obj);
+  void defaultCase(Object obj);
 }

--- a/src/main/java/de/upb/soot/namespaces/classprovider/IClassSourceContent.java
+++ b/src/main/java/de/upb/soot/namespaces/classprovider/IClassSourceContent.java
@@ -13,5 +13,5 @@ import de.upb.soot.views.IView;
  * @author Manuel Benz
  */
 public interface IClassSourceContent {
-  public AbstractClass resolve(ResolvingLevel level, IView view);
+  AbstractClass resolve(ResolvingLevel level, IView view);
 }

--- a/src/main/java/de/upb/soot/namespaces/classprovider/IMethodSourceContent.java
+++ b/src/main/java/de/upb/soot/namespaces/classprovider/IMethodSourceContent.java
@@ -31,6 +31,6 @@ import de.upb.soot.signatures.MethodSignature;
 
 public interface IMethodSourceContent {
   /** Returns a filled-out body for the given SootMethod. */
-  public Body getBody(SootMethod m);
-  public MethodSignature getSignature();
+  Body getBody(SootMethod m);
+  MethodSignature getSignature();
 }

--- a/src/main/java/de/upb/soot/util/Numberable.java
+++ b/src/main/java/de/upb/soot/util/Numberable.java
@@ -25,7 +25,7 @@ package de.upb.soot.util;
  * @author Ondrej Lhotak
  */
 public interface Numberable {
-  public void setNumber(int number);
+  void setNumber(int number);
 
-  public int getNumber();
+  int getNumber();
 }

--- a/src/main/java/de/upb/soot/util/Numberer.java
+++ b/src/main/java/de/upb/soot/util/Numberer.java
@@ -32,16 +32,16 @@ package de.upb.soot.util;
 
 public interface Numberer<E> {
   /** Tells the numberer that a new object needs to be assigned a number. */
-  public void add(E o);
+  void add(E o);
 
   /**
    * Should return the number that was assigned to object o that was previously passed as an argument to add().
    */
-  public long get(E o);
+  long get(E o);
 
   /** Should return the object that was assigned the number number. */
-  public E get(long number);
+  E get(long number);
 
   /** Should return the number of objects that have been assigned numbers. */
-  public int size();
+  int size();
 }

--- a/src/main/java/de/upb/soot/util/printer/IStmtPrinter.java
+++ b/src/main/java/de/upb/soot/util/printer/IStmtPrinter.java
@@ -38,49 +38,49 @@ import de.upb.soot.signatures.MethodSignature;
  * Interface for different methods of printing out a IStmt.
  */
 public interface IStmtPrinter {
-  public void startStmt(IStmt u);
+  void startStmt(IStmt u);
 
-  public void endStmt(IStmt u);
+  void endStmt(IStmt u);
 
-  public void startStmtBox(IStmtBox u);
+  void startStmtBox(IStmtBox u);
 
-  public void endStmtBox(IStmtBox u);
+  void endStmtBox(IStmtBox u);
 
-  public void startValueBox(ValueBox u);
+  void startValueBox(ValueBox u);
 
-  public void endValueBox(ValueBox u);
+  void endValueBox(ValueBox u);
 
-  public void incIndent();
+  void incIndent();
 
-  public void decIndent();
+  void decIndent();
 
-  public void noIndent();
+  void noIndent();
 
-  public void setIndent(String newIndent);
+  void setIndent(String newIndent);
 
-  public String getIndent();
+  String getIndent();
 
-  public void literal(String s);
+  void literal(String s);
 
-  public void newline();
+  void newline();
 
-  public void local(Local jimpleLocal);
+  void local(Local jimpleLocal);
 
-  public void type(Type t);
+  void type(Type t);
 
-  public void methodSignature(MethodSignature sig);
+  void methodSignature(MethodSignature sig);
 
-  public void method(SootMethod m);
+  void method(SootMethod m);
 
-  public void constant(Constant c);
+  void constant(Constant c);
 
-  public void field(SootField f);
+  void field(SootField f);
 
-  public void fieldSignature(FieldSignature fieldSig);
+  void fieldSignature(FieldSignature fieldSig);
 
-  public void stmtRef(IStmt u, boolean branchTarget);
+  void stmtRef(IStmt u, boolean branchTarget);
 
-  public void identityRef(IdentityRef r);
+  void identityRef(IdentityRef r);
 
-  public StringBuffer output();
+  StringBuffer output();
 }

--- a/src/main/java/de/upb/soot/validation/BodyValidator.java
+++ b/src/main/java/de/upb/soot/validation/BodyValidator.java
@@ -38,7 +38,7 @@ public interface BodyValidator {
    * @param exceptions
    *          the list of exceptions
    */
-  public void validate(Body body, List<ValidationException> exceptions);
+  void validate(Body body, List<ValidationException> exceptions);
 
   /**
    * Basic validators run essential checks and are run always if validate is called.<br>
@@ -47,5 +47,5 @@ public interface BodyValidator {
    * 
    * @return whether this validator is a basic validator
    */
-  public boolean isBasicValidator();
+  boolean isBasicValidator();
 }

--- a/src/main/java/de/upb/soot/validation/ClassValidator.java
+++ b/src/main/java/de/upb/soot/validation/ClassValidator.java
@@ -37,7 +37,7 @@ public interface ClassValidator {
    *          the class to check
    * @param exceptions
    */
-  public void validate(SootClass sc, List<ValidationException> exceptions);
+  void validate(SootClass sc, List<ValidationException> exceptions);
 
   /**
    * Basic validators run essential checks and are run always if validate is called.<br>
@@ -46,5 +46,5 @@ public interface ClassValidator {
    *
    * @return whether this validator is a basic validator
    */
-  public boolean isBasicValidator();
+  boolean isBasicValidator();
 }


### PR DESCRIPTION
I've noticed that in lots of interfaces, methods were declared as `public` or even `public abstract`. In Java, this is the default for interface methods anyway, so we could remove this redundancy. I've also ran other IntelliJ inspections and found many small issues that could be easily corrected, for example usages of the slow `StringBuffer` vs `StringBuilder`. If desired, I could investigate those issues.

Furthermore, I've been wondering what the point of the `EquivTo` interface is. When I used Soot in the DECA labs, I was often unsure whether `equals` or `equivTo` should be used and the documentation of the interface doesn't make it obvious for me. Especially the overload taking the `Comparator` is interesting; why would I use it instead of just using the `compare` method of the `Comparator` itself? I'm sure there is a reason, but maybe we can document it better?