### PR TITLE
fix jimple parser backwards compatibility for escaped sequences

### DIFF
--- a/de.upb.swt.soot.jimple.parser/src/main/antlr4/de/upb/swt/soot/jimple/Jimple.g4
+++ b/de.upb.swt.soot.jimple.parser/src/main/antlr4/de/upb/swt/soot/jimple/Jimple.g4
@@ -7,8 +7,7 @@ grammar Jimple;
   LINE_COMMENT : '//' ~('\n'|'\r')* ->skip;
   LONG_COMMENT : '/*' ~('*')* '*'+ ( ~('*' | '/')* ~('*')* '*'+)*? '/' -> skip;
 
-  HYPHEN: ('"' | '\'');
-  STRING_CONSTANT : HYPHEN STRING_CHAR* HYPHEN;
+  STRING_CONSTANT : '"' STRING_CHAR* '"' |  '\'' STRING_CHAR* '\'';
 
   CLASS : 'class';
   EXTENDS : 'extends';
@@ -98,7 +97,7 @@ grammar Jimple;
     '0' ('x' | 'X') HEX_DIGIT+;
 
   fragment ESCAPABLE_CHAR :
-    '\\' | ' ' | '\'' | '.' | HYPHEN | 'n' | 't' | 'r' | 'b' | 'f';
+    '\\' | ' ' | '\'' | '"' | '.'  | 'n' | 't' | 'r' | 'b' | 'f';
   fragment ESCAPE_CHAR :
     '\\' (ESCAPABLE_CHAR | 'u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT );
 

--- a/de.upb.swt.soot.jimple.parser/src/main/java/de/upb/swt/soot/jimple/parser/JimpleConverter.java
+++ b/de.upb.swt.soot.jimple.parser/src/main/java/de/upb/swt/soot/jimple/parser/JimpleConverter.java
@@ -93,7 +93,7 @@ public class JimpleConverter {
       if (ctx.classname != null) {
 
         // "$" in classname is a heuristic for an inner/outer class
-        final String classname = Jimple.unescape(ctx.classname.getText());
+        final String classname = ctx.classname.getText();
         final int dollarPostition = classname.indexOf('$');
         if (dollarPostition > -1) {
           outerclass = util.getClassType(classname.substring(0, dollarPostition));
@@ -118,7 +118,7 @@ public class JimpleConverter {
 
       // extends_clause
       if (ctx.extends_clause() != null) {
-        superclass = util.getClassType(Jimple.unescape(ctx.extends_clause().classname.getText()));
+        superclass = util.getClassType(ctx.extends_clause().classname.getText());
       } else {
         superclass = null;
       }


### PR DESCRIPTION
parsing was not working for identifiers with escaped sequence at the beginning like ```"annotation".package.morepackage.SomeClass``` which could be produced this way by old soot.