### PR TITLE
Fix #289

### DIFF
--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/frontend/AsmMethodSource.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/frontend/AsmMethodSource.java
@@ -836,14 +836,6 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
     } else {
       final Operand operand = dword ? operandStack.popDual() : operandStack.pop();
       frame.mergeIn(operand);
-      // TODO: [ms] hack: please investigate this change further - somewhere there is an underlying
-      // bug likely associated with Value/ValueBox which is solved via remove(insn)/setStmt(..)
-      InsnToStmt.remove(insn);
-      JReturnStmt ret =
-          Jimple.newReturnStmt(
-              (Immediate) operand.stackOrValue(), StmtPositionInfo.createNoStmtPositionInfo());
-      setStmt(insn, ret);
-      operand.addUsageInStmt(ret);
     }
   }
 


### PR DESCRIPTION
> please investigate this change further:
frame.mergeIn didnt work as expected ( return returned a number instead of a stack variable) - we fixed it with "hard replacing" the stmt via remove+put
>
>somewhere there is an underlying bug - likely associated with Value/ValueBox

This bug was fixed during the removal of ValueBox.