### PR TITLE
Refactor methods into bodybuilder

### DIFF
--- a/de.upb.swt.soot.core/src/main/java/de/upb/swt/soot/core/model/Body.java
+++ b/de.upb.swt.soot.core/src/main/java/de/upb/swt/soot/core/model/Body.java
@@ -555,8 +555,6 @@ public class Body implements Copyable {
       this.setTraps(traps);
     }
 
-
-
     /** remove the a stmt from the graph and stmt */
     @Nonnull
     public BodyBuilder removeStmt(@Nonnull Stmt stmt) {
@@ -696,15 +694,12 @@ public class Body implements Copyable {
       return modifiers;
     }
 
-
-    /**
-     * Removes a stmt and all of it's then unreachable sucessor stmts
-     */
+    /** Removes a stmt and all of it's then unreachable sucessor stmts */
     public BodyBuilder removeStmtAndUnreachableSuccessors(Stmt stmt) {
       final StmtGraph stmtGraph = this.getStmtGraph();
       Deque<Stmt> stack = new ArrayDeque<>();
       stack.addFirst(stmt);
-      
+
       while (!stack.isEmpty()) {
         Stmt itStmt = stack.pollFirst();
         if (stmtGraph.containsNode(itStmt)) {
@@ -743,6 +738,5 @@ public class Body implements Copyable {
 
       return this;
     }
-
   }
 }

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/Aggregator.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/Aggregator.java
@@ -73,13 +73,10 @@ public class Aggregator implements BodyInterceptor {
                   boolean propagatingArrayRef = false;
                   List<JFieldRef> fieldRefList = new ArrayList<>();
 
-                  List<Value> localsUsed = new ArrayList<>();
                   for (Stmt pathStmt : path) {
                     List<Value> allDefs = pathStmt.getDefs();
                     for (Value def : allDefs) {
-                      if (def instanceof Local) {
-                        localsUsed.add(def);
-                      } else if (def instanceof AbstractInstanceInvokeExpr) {
+                      if (def instanceof AbstractInstanceInvokeExpr) {
                         propagatingInvokeExpr = true;
                       } else if (def instanceof JArrayRef) {
                         propagatingArrayRef = true;
@@ -92,15 +89,6 @@ public class Aggregator implements BodyInterceptor {
                   for (Stmt pathStmt : path) {
                     if (pathStmt != stmt && pathStmt != relevantDef) {
                       for (Value stmtDef : pathStmt.getDefs()) {
-                        if (localsUsed.contains(stmtDef)) {
-                          // TODO [bh] removing the next line will make the AggregatorTest run,
-                          // but I think there is something else wrong here. cantAggr
-                          // is a boolean for each value of the definition we might collapse
-                          // so we should only care about locals that use values of the definition
-                          // or the value we currently iterate, right?
-                          cantAggr = true;
-                          break;
-                        }
                         if (propagatingInvokeExpr || propagatingFieldRef || propagatingArrayRef) {
                           if (stmtDef instanceof JFieldRef) {
                             if (propagatingInvokeExpr) {

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/Aggregator.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/Aggregator.java
@@ -93,6 +93,10 @@ public class Aggregator implements BodyInterceptor {
                     if (pathStmt != stmt && pathStmt != relevantDef) {
                       for (Value stmtDef : pathStmt.getDefs()) {
                         if (localsUsed.contains(stmtDef)) {
+                          // TODO [bh] removing the next line will make the AggregatorTest run,
+                          // but I think there is something else wrong here. cantAggr
+                          // is a boolean for each value of the definition we might collapse
+                          // so we should only care about locals that use values of the definition or the value we currently iterate, right?
                           cantAggr = true;
                           break;
                         }
@@ -142,6 +146,7 @@ public class Aggregator implements BodyInterceptor {
                     continue;
                   }
 
+
                   Value aggregatee = ((JAssignStmt<?, ?>) relevantDef).getRightOp();
                   JAssignStmt<?, ?> newStmt = null;
                   if (assignStmt.getRightOp() instanceof AbstractBinopExpr) {
@@ -162,11 +167,7 @@ public class Aggregator implements BodyInterceptor {
                   }
                   if (newStmt != null) {
                     builder.replaceStmt(stmt, newStmt);
-                    if (graph.getStartingStmt() == relevantDef) {
-                      Stmt newStartingStmt = builder.getStmtGraph().successors(relevantDef).get(0);
-                      builder.setStartingStmt(newStartingStmt);
-                    }
-                    builder.removeStmt(relevantDef);
+                    builder.removeStmtAndLinkPredecessorsToSuccessors(relevantDef);
                   }
                 }
               }

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/Aggregator.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/Aggregator.java
@@ -96,7 +96,8 @@ public class Aggregator implements BodyInterceptor {
                           // TODO [bh] removing the next line will make the AggregatorTest run,
                           // but I think there is something else wrong here. cantAggr
                           // is a boolean for each value of the definition we might collapse
-                          // so we should only care about locals that use values of the definition or the value we currently iterate, right?
+                          // so we should only care about locals that use values of the definition
+                          // or the value we currently iterate, right?
                           cantAggr = true;
                           break;
                         }
@@ -145,7 +146,6 @@ public class Aggregator implements BodyInterceptor {
                   if (cantAggr) {
                     continue;
                   }
-
 
                   Value aggregatee = ((JAssignStmt<?, ?>) relevantDef).getRightOp();
                   JAssignStmt<?, ?> newStmt = null;

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/ConditionalBranchFolder.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/ConditionalBranchFolder.java
@@ -28,8 +28,6 @@ import de.upb.swt.soot.core.jimple.common.stmt.JIfStmt;
 import de.upb.swt.soot.core.jimple.common.stmt.Stmt;
 import de.upb.swt.soot.core.model.Body;
 import de.upb.swt.soot.core.transform.BodyInterceptor;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.List;
 import javax.annotation.Nonnull;
 

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/ConditionalBranchFolder.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/ConditionalBranchFolder.java
@@ -76,19 +76,7 @@ public class ConditionalBranchFolder implements BodyInterceptor {
               builder.addFlow(predecessor, branchTarget);
             }
 
-            Deque<Stmt> stack = new ArrayDeque<>();
-            stack.addFirst(fallsThroughStmt);
-            // remove all now unreachable stmts from "true"-block
-            while (!stack.isEmpty()) {
-              Stmt itStmt = stack.pollFirst();
-              if (builderStmtGraph.containsNode(itStmt)
-                  && builderStmtGraph.predecessors(itStmt).size() < 1) {
-                for (Stmt succ : stmtGraph.successors(itStmt)) {
-                  builder.removeFlow(itStmt, succ);
-                  stack.add(succ);
-                }
-              }
-            }
+            builder.removeStmtAndUnreachableSuccessors(fallsThroughStmt);
           }
         }
       }

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/DeadAssignmentEliminator.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/DeadAssignmentEliminator.java
@@ -208,15 +208,7 @@ public class DeadAssignmentEliminator implements BodyInterceptor {
         // Remove the dead statements
         for (Stmt stmt : stmts) {
           if (!essential.contains(stmt)) {
-            for (Stmt predecessor : stmtGraph.predecessors(stmt)) {
-              builder.removeFlow(predecessor, stmt);
-              for (Stmt successor : stmtGraph.successors(stmt)) {
-                builder.addFlow(predecessor, successor);
-              }
-            }
-            for (Stmt successor : stmtGraph.successors(stmt)) {
-              builder.removeFlow(stmt, successor);
-            }
+            builder.removeStmtAndLinkPredecessorsToSuccessors(stmt);
           }
         }
       }

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/LocalPacker.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/LocalPacker.java
@@ -119,7 +119,7 @@ public class LocalPacker implements BodyInterceptor {
         newStmt = BodyUtils.withNewDef(newStmt, newLocal);
       }
       if (!stmt.equals(newStmt)) {
-        replaceStmtInBuilder(builder, stmt, newStmt);
+        builder.replaceStmt(stmt, newStmt);
       }
     }
     builder.setLocals(newLocals);
@@ -249,40 +249,6 @@ public class LocalPacker implements BodyInterceptor {
       }
     }
     return localToLocals;
-  }
-
-  /**
-   * Replace corresponding oldStmt with newStmt in BodyBuilder
-   *
-   * @param builder
-   * @param oldStmt
-   * @param newStmt
-   */
-  private void replaceStmtInBuilder(Body.BodyBuilder builder, Stmt oldStmt, Stmt newStmt) {
-    builder.replaceStmt(oldStmt, newStmt);
-    adaptTraps(builder, oldStmt, newStmt);
-  }
-  /**
-   * Fit the modified stmt in Traps
-   *
-   * @param builder a bodybuilder, use it to modify Trap
-   * @param oldStmt a Stmt which maybe a beginStmt or endStmt in a Trap
-   * @param newStmt a modified stmt to replace the oldStmt.
-   */
-  private void adaptTraps(
-      @Nonnull Body.BodyBuilder builder, @Nonnull Stmt oldStmt, @Nonnull Stmt newStmt) {
-    List<Trap> traps = new ArrayList<>(builder.getStmtGraph().getTraps());
-    for (ListIterator<Trap> iterator = traps.listIterator(); iterator.hasNext(); ) {
-      Trap trap = iterator.next();
-      if (oldStmt.equivTo(trap.getBeginStmt())) {
-        Trap newTrap = trap.withBeginStmt(newStmt);
-        iterator.set(newTrap);
-      } else if (oldStmt.equivTo(trap.getEndStmt())) {
-        Trap newTrap = trap.withEndStmt(newStmt);
-        iterator.set(newTrap);
-      }
-    }
-    builder.setTraps(traps);
   }
 
   private class TypeColorPair {

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/LocalPacker.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/LocalPacker.java
@@ -22,7 +22,6 @@ package de.upb.swt.soot.java.bytecode.interceptors;
  */
 import de.upb.swt.soot.core.graph.StmtGraph;
 import de.upb.swt.soot.core.jimple.basic.Local;
-import de.upb.swt.soot.core.jimple.basic.Trap;
 import de.upb.swt.soot.core.jimple.basic.Value;
 import de.upb.swt.soot.core.jimple.common.stmt.JIdentityStmt;
 import de.upb.swt.soot.core.jimple.common.stmt.Stmt;

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/LocalSplitter.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/LocalSplitter.java
@@ -270,30 +270,7 @@ public class LocalSplitter implements BodyInterceptor {
   private void replaceStmtInBuilder(
       BodyBuilder builder, List<Stmt> stmts, Stmt oldStmt, Stmt newStmt) {
     builder.replaceStmt(oldStmt, newStmt);
-    adaptTraps(builder, oldStmt, newStmt);
     adaptVisitList(stmts, oldStmt, newStmt);
-  }
-  /**
-   * Fit the modified stmt in Traps
-   *
-   * @param builder a bodybuilder, use it to modify Trap
-   * @param oldStmt a Stmt which maybe a beginStmt or endStmt in a Trap
-   * @param newStmt a modified stmt to replace the oldStmt.
-   */
-  private void adaptTraps(
-      @Nonnull BodyBuilder builder, @Nonnull Stmt oldStmt, @Nonnull Stmt newStmt) {
-    List<Trap> traps = new ArrayList<>(builder.getStmtGraph().getTraps());
-    for (ListIterator<Trap> iterator = traps.listIterator(); iterator.hasNext(); ) {
-      Trap trap = iterator.next();
-      if (oldStmt.equivTo(trap.getBeginStmt())) {
-        Trap newTrap = trap.withBeginStmt(newStmt);
-        iterator.set(newTrap);
-      } else if (oldStmt.equivTo(trap.getEndStmt())) {
-        Trap newTrap = trap.withEndStmt(newStmt);
-        iterator.set(newTrap);
-      }
-    }
-    builder.setTraps(traps);
   }
 
   /**

--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/NopEliminator.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/interceptors/NopEliminator.java
@@ -51,16 +51,7 @@ public class NopEliminator implements BodyInterceptor {
     builder.enableDeferredStmtGraphChanges();
     for (Stmt stmt : stmtSet) {
       if (stmt instanceof JNopStmt) {
-        final Stmt nopStmt = stmt;
-        final List<Stmt> successors = graph.successors(stmt);
-        // relink predecessors to successor of nop
-        // [ms] in a valid Body there is always a successor of nop
-        final Stmt successorOfNop = successors.iterator().next();
-        builder.removeFlow(nopStmt, successorOfNop);
-        for (Stmt pred : graph.predecessors(nopStmt)) {
-          builder.removeFlow(pred, nopStmt);
-          builder.addFlow(pred, successorOfNop);
-        }
+        builder.removeStmtAndLinkPredecessorsToSuccessors(stmt);
       }
     }
     builder.commitDeferredStmtGraphChanges();

--- a/de.upb.swt.soot.java.bytecode/src/test/java/de/upb/swt/soot/test/java/bytecode/interceptors/AggregatorTest.java
+++ b/de.upb.swt.soot.java.bytecode/src/test/java/de/upb/swt/soot/test/java/bytecode/interceptors/AggregatorTest.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class AggregatorTest {
@@ -34,7 +33,6 @@ public class AggregatorTest {
    * <p>i = 0; b = 7 + 4; return;
    */
   @Test
-  @Ignore("FIX ME")
   public void testAggregation() {
     Body.BodyBuilder testBuilder = createBody(true);
     Body testBody = testBuilder.build();
@@ -42,12 +40,6 @@ public class AggregatorTest {
     Body processedBody = testBuilder.build();
     List<Stmt> originalStmts = testBody.getStmts();
     List<Stmt> processedStmts = processedBody.getStmts();
-    System.out.println("new");
-    processedStmts.forEach(System.out::println);
-    System.out.println("old");
-    originalStmts.forEach(System.out::println);
-
-    System.out.println(processedBody.getStmtGraph().getStartingStmt());
 
     assertEquals(originalStmts.size() - 1, processedStmts.size());
     assertEquals("b = a + 4", originalStmts.get(3).toString());


### PR DESCRIPTION
- moves stmt graph modifications into bodybuilder
- fixes a bug in aggregator

@marcusna You wrote the aggregator, so asking you directly. I removed the local check, as I only saw a few cases here:

```
a = 3
i = 0
b = a + 7
```
i is completely irrelevant, so we do not care about that

```
a = 3
a = 2
b = a + 7
```
the second statement is a second Def, but we only continue if there is exactly one definition for a 

```
a = 3
b = 0
b = a + 7
```
first definition for b is irrelevant for this bodyinterceptor

```
a = 3
b = 3
b = b + a
```
first definition for b is irrelevant for this bodyinterceptor

so I think we do not need to track locals, right? Is there something I forgot?
