### PR TITLE
Fix Reference to newFileSystem is ambiguous

### DIFF
--- a/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/inputlocation/PathBasedAnalysisInputLocation.java
+++ b/de.upb.swt.soot.java.bytecode/src/main/java/de/upb/swt/soot/java/bytecode/inputlocation/PathBasedAnalysisInputLocation.java
@@ -584,7 +584,7 @@ public class PathBasedAnalysisInputLocation implements AnalysisInputLocation<Jav
         @Nonnull View<?> view) {
       // we don't use the filesystem cache here as it could close the filesystem after the timeout
       // while we are still iterating
-      try (FileSystem fs = FileSystems.newFileSystem(path, null)) {
+      try (FileSystem fs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
         final Path archiveRoot = fs.getPath("/");
         return walkDirectory(
             archiveRoot,


### PR DESCRIPTION
Fix a compilation error as the Java compiler does not know which method should be called.

`[ERROR]   both method newFileSystem(java.nio.file.Path,java.lang.ClassLoader) in java.nio.file.FileSystems and method newFileSystem(java.nio.file.Path,java.util.Map<java.lang.String,?>) in java.nio.file.FileSystems match`