### PR TITLE
create wala.properties not in a maven dependent dir

### DIFF
--- a/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/WalaJavaClassProvider.java
+++ b/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/WalaJavaClassProvider.java
@@ -69,7 +69,7 @@ public class WalaJavaClassProvider implements ClassProvider<JavaSootClass> {
   private List<SootClassSource<JavaSootClass>> classSources;
   private AnalysisScope scope;
   private ClassLoaderFactory factory;
-  private final File walaPropertiesFile = new File("target/classes/wala.properties");
+  private final File walaPropertiesFile = new File("wala.properties");
 
   public WalaJavaClassProvider(@Nonnull String sourceDirPath) {
     this(sourceDirPath, null);


### PR DESCRIPTION
creates the file wala needs in the executing dir  source code frontend dir instead of the a dir that is usually created by maven in the standard config
closes #534