### PR TITLE
Move fmt check earlier in the pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,24 @@ concurrency:
 
 jobs:
   # Code coverage (i.e. jacoco) needs the same classes for its test otherwise its classids can possibly not match
+
+  FormatCheck:
+    runs-one: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      # style check is not clean here but does not consume additional time as the other parallel running tests take (way) longer
+      - name: Check Format
+        run: mvn -B com.coveo:fmt-maven-plugin:check -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
   Compilation:
+    needs: FormatCheck
     runs-on: ubuntu-latest
     
     steps:
@@ -142,10 +159,6 @@ jobs:
           name: test-reports-jdk9
           path: |
             */target/surefire-reports
-
-      # style check is not clean here but does not consume additional time as the other parallel running tests take (way) longer
-      - name: Check Format
-        run: mvn -B com.coveo:fmt-maven-plugin:check -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       
 
     # takes a long time to run - so just run them when PR is not draft anymore

--- a/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
+++ b/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
@@ -105,7 +105,7 @@ grammar Jimple;
   fragment STRING_CHAR :  ESCAPE_CHAR | ~('\\' | '"' | '\'') ;
 
   IDENTIFIER:
-    (([A-Za-z$_] | ESCAPE_CHAR) ( (ESCAPE_CHAR | [A-Za-z0-9$_] | STRING_CONSTANT) | '.' (ESCAPE_CHAR | [A-Za-z0-9$_] | STRING_CONSTANT) )*);
+    (([\p{L}$_] | ESCAPE_CHAR) ( (ESCAPE_CHAR | [\p{L}0-9$_] | STRING_CONSTANT) | '.' (ESCAPE_CHAR | [\p{L}0-9$_] | STRING_CONSTANT) )*);
 
   BLANK :
     [ \t\r\n] ->skip;

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AlphaBetaGamma.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AlphaBetaGamma.jimple
@@ -1,0 +1,9 @@
+public class AlphaBetaGamma extends java.lang.Object
+{
+
+    public void αβγ()
+    {
+
+        return;
+    }
+}

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/AlphaBetaGammaTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/AlphaBetaGammaTest.java
@@ -1,5 +1,6 @@
 package sootup.jimple.parser.javatestsuite.java6;
 
+import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -8,20 +9,17 @@ import sootup.core.signatures.MethodSignature;
 import sootup.jimple.parser.categories.Java8Test;
 import sootup.jimple.parser.javatestsuite.JimpleTestSuiteBase;
 
-import java.util.Collections;
-
 @Category(Java8Test.class)
 public class AlphaBetaGammaTest extends JimpleTestSuiteBase {
 
-    public MethodSignature getMethodSignature() {
-        return identifierFactory.getMethodSignature(
-                getDeclaredClassSignature(), "αβγ", "void", Collections.emptyList());
-    }
+  public MethodSignature getMethodSignature() {
+    return identifierFactory.getMethodSignature(
+        getDeclaredClassSignature(), "αβγ", "void", Collections.emptyList());
+  }
 
-    @Test
-    public void test() {
-        SootMethod method = loadMethod(getMethodSignature());
-        Assert.assertEquals("αβγ", method.getName());
-    }
-
+  @Test
+  public void test() {
+    SootMethod method = loadMethod(getMethodSignature());
+    Assert.assertEquals("αβγ", method.getName());
+  }
 }

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/AlphaBetaGammaTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/AlphaBetaGammaTest.java
@@ -1,0 +1,27 @@
+package sootup.jimple.parser.javatestsuite.java6;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import sootup.core.model.SootMethod;
+import sootup.core.signatures.MethodSignature;
+import sootup.jimple.parser.categories.Java8Test;
+import sootup.jimple.parser.javatestsuite.JimpleTestSuiteBase;
+
+import java.util.Collections;
+
+@Category(Java8Test.class)
+public class AlphaBetaGammaTest extends JimpleTestSuiteBase {
+
+    public MethodSignature getMethodSignature() {
+        return identifierFactory.getMethodSignature(
+                getDeclaredClassSignature(), "αβγ", "void", Collections.emptyList());
+    }
+
+    @Test
+    public void test() {
+        SootMethod method = loadMethod(getMethodSignature());
+        Assert.assertEquals("αβγ", method.getName());
+    }
+
+}


### PR DESCRIPTION
Move fmt check earlier in the pipeline so that it doesn't fully run and then fail just because of formatting.
Rather it should fail immediately and not continue running the pipeline.