### PR TITLE
Use guava Cache instead of HashMap for concurrency

### DIFF
--- a/sootup.java.core/src/main/java/sootup/java/core/JavaIdentifierFactory.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaIdentifierFactory.java
@@ -59,10 +59,14 @@ public class JavaIdentifierFactory implements IdentifierFactory {
   @Nonnull private static final JavaIdentifierFactory INSTANCE = new JavaIdentifierFactory();
 
   /** Caches the created PackageNames for packages. */
-  @Nonnull protected final Cache<String, PackageName> packages = CacheBuilder.newBuilder().weakValues().build();
+  @Nonnull
+  protected final Cache<String, PackageName> packages =
+      CacheBuilder.newBuilder().weakValues().build();
 
   /** Caches annotation types */
-  @Nonnull protected final Cache<String, AnnotationType> annotationTypes = CacheBuilder.newBuilder().weakValues().build();
+  @Nonnull
+  protected final Cache<String, AnnotationType> annotationTypes =
+      CacheBuilder.newBuilder().weakValues().build();
 
   @Nonnull
   protected final Map<String, PrimitiveType> primitiveTypeMap = Maps.newHashMapWithExpectedSize(8);
@@ -212,8 +216,11 @@ public class JavaIdentifierFactory implements IdentifierFactory {
     String className = ClassUtils.getShortClassName(fullyQualifiedClassName);
     String packageName = ClassUtils.getPackageName(fullyQualifiedClassName);
 
-    return annotationTypes.asMap().computeIfAbsent(
-        className + packageName, (k) -> new AnnotationType(className, getPackageName(packageName)));
+    return annotationTypes
+        .asMap()
+        .computeIfAbsent(
+            className + packageName,
+            (k) -> new AnnotationType(className, getPackageName(packageName)));
   }
 
   @Override

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaIdentifierFactory.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaIdentifierFactory.java
@@ -22,6 +22,8 @@ package sootup.java.core;
  * #L%
  */
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Maps;
 import java.nio.file.Path;
 import java.util.*;
@@ -57,10 +59,10 @@ public class JavaIdentifierFactory implements IdentifierFactory {
   @Nonnull private static final JavaIdentifierFactory INSTANCE = new JavaIdentifierFactory();
 
   /** Caches the created PackageNames for packages. */
-  @Nonnull protected final Map<String, PackageName> packages = new HashMap<>();
+  @Nonnull protected final Cache<String, PackageName> packages = CacheBuilder.newBuilder().weakValues().build();
 
   /** Caches annotation types */
-  @Nonnull protected final Map<String, AnnotationType> annotationTypes = new HashMap<>();
+  @Nonnull protected final Cache<String, AnnotationType> annotationTypes = CacheBuilder.newBuilder().weakValues().build();
 
   @Nonnull
   protected final Map<String, PrimitiveType> primitiveTypeMap = Maps.newHashMapWithExpectedSize(8);
@@ -210,7 +212,7 @@ public class JavaIdentifierFactory implements IdentifierFactory {
     String className = ClassUtils.getShortClassName(fullyQualifiedClassName);
     String packageName = ClassUtils.getPackageName(fullyQualifiedClassName);
 
-    return annotationTypes.computeIfAbsent(
+    return annotationTypes.asMap().computeIfAbsent(
         className + packageName, (k) -> new AnnotationType(className, getPackageName(packageName)));
   }
 
@@ -251,7 +253,7 @@ public class JavaIdentifierFactory implements IdentifierFactory {
    */
   @Override
   public PackageName getPackageName(@Nonnull final String packageName) {
-    return packages.computeIfAbsent(packageName, (name) -> new PackageName(name));
+    return packages.asMap().computeIfAbsent(packageName, PackageName::new);
   }
 
   /**

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaModuleIdentifierFactory.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaModuleIdentifierFactory.java
@@ -36,7 +36,8 @@ public class JavaModuleIdentifierFactory extends JavaIdentifierFactory {
 
   public static final String MODULE_INFO_FILE = "module-info";
 
-  private static final Cache<String, ModuleSignature> modules = CacheBuilder.newBuilder().weakValues().build();
+  private static final Cache<String, ModuleSignature> modules =
+      CacheBuilder.newBuilder().weakValues().build();
 
   private static final JavaModuleIdentifierFactory INSTANCE = new JavaModuleIdentifierFactory();
 
@@ -52,8 +53,9 @@ public class JavaModuleIdentifierFactory extends JavaIdentifierFactory {
       moduleIdentifierFactoryWrapper = CacheBuilder.newBuilder().weakValues().build();
 
   public static JavaModuleIdentifierFactory getInstance(@Nonnull ModuleSignature moduleSignature) {
-    return moduleIdentifierFactoryWrapper.asMap().computeIfAbsent(
-            moduleSignature, JavaModuleIdentifierFactoryWrapper::new);
+    return moduleIdentifierFactoryWrapper
+        .asMap()
+        .computeIfAbsent(moduleSignature, JavaModuleIdentifierFactoryWrapper::new);
   }
 
   static {
@@ -160,15 +162,20 @@ public class JavaModuleIdentifierFactory extends JavaIdentifierFactory {
   public ModulePackageName getPackageName(
       @Nonnull final String packageName, @Nonnull final String moduleName) {
     String fqId = moduleName + "." + packageName;
-    return (ModulePackageName) packages.asMap().computeIfAbsent(
-            fqId, key -> new ModulePackageName(packageName, getModuleSignature(moduleName)));
+    return (ModulePackageName)
+        packages
+            .asMap()
+            .computeIfAbsent(
+                fqId, key -> new ModulePackageName(packageName, getModuleSignature(moduleName)));
   }
 
   public ModulePackageName getPackageName(
       @Nonnull final String packageName, @Nonnull final ModuleSignature moduleSignature) {
     String fqId = moduleSignature.getModuleName() + "." + packageName;
-    return (ModulePackageName) packages.asMap().computeIfAbsent(
-            fqId, key -> new ModulePackageName(packageName, moduleSignature));
+    return (ModulePackageName)
+        packages
+            .asMap()
+            .computeIfAbsent(fqId, key -> new ModulePackageName(packageName, moduleSignature));
   }
 
   /** Wrapper which refers to a given ModuleSignature when building stuff */

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaModuleIdentifierFactory.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaModuleIdentifierFactory.java
@@ -22,9 +22,9 @@ package sootup.java.core;
  * #L%
  */
 
-import java.util.HashMap;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.ClassUtils;
 import sootup.core.signatures.MethodSignature;
@@ -36,7 +36,7 @@ public class JavaModuleIdentifierFactory extends JavaIdentifierFactory {
 
   public static final String MODULE_INFO_FILE = "module-info";
 
-  private static final Map<String, ModuleSignature> modules = new HashMap<>();
+  private static final Cache<String, ModuleSignature> modules = CacheBuilder.newBuilder().weakValues().build();
 
   private static final JavaModuleIdentifierFactory INSTANCE = new JavaModuleIdentifierFactory();
 
@@ -48,13 +48,12 @@ public class JavaModuleIdentifierFactory extends JavaIdentifierFactory {
     return getInstance(getModuleSignature(module));
   }
 
-  private static final Map<ModuleSignature, JavaModuleIdentifierFactory>
-      moduleIdentifierFactoryWrapper = new HashMap<>();
+  private static final Cache<ModuleSignature, JavaModuleIdentifierFactory>
+      moduleIdentifierFactoryWrapper = CacheBuilder.newBuilder().weakValues().build();
 
   public static JavaModuleIdentifierFactory getInstance(@Nonnull ModuleSignature moduleSignature) {
-    return moduleIdentifierFactoryWrapper.computeIfAbsent(
-        moduleSignature,
-        methodSignature -> new JavaModuleIdentifierFactoryWrapper(moduleSignature));
+    return moduleIdentifierFactoryWrapper.asMap().computeIfAbsent(
+            moduleSignature, JavaModuleIdentifierFactoryWrapper::new);
   }
 
   static {
@@ -139,12 +138,7 @@ public class JavaModuleIdentifierFactory extends JavaIdentifierFactory {
    *     the unnamed module.
    */
   public static ModuleSignature getModuleSignature(@Nonnull final String moduleName) {
-    ModuleSignature moduleSignature = modules.get(moduleName);
-    if (moduleSignature == null) {
-      moduleSignature = new ModuleSignature(moduleName);
-      modules.put(moduleName, moduleSignature);
-    }
-    return moduleSignature;
+    return modules.asMap().computeIfAbsent(moduleName, ModuleSignature::new);
   }
 
   @Override
@@ -166,24 +160,15 @@ public class JavaModuleIdentifierFactory extends JavaIdentifierFactory {
   public ModulePackageName getPackageName(
       @Nonnull final String packageName, @Nonnull final String moduleName) {
     String fqId = moduleName + "." + packageName;
-    ModulePackageName packageSignature = (ModulePackageName) packages.get(fqId);
-    if (packageSignature == null) {
-      ModuleSignature moduleSignature = getModuleSignature(moduleName);
-      packageSignature = new ModulePackageName(packageName, moduleSignature);
-      packages.put(fqId, packageSignature);
-    }
-    return packageSignature;
+    return (ModulePackageName) packages.asMap().computeIfAbsent(
+            fqId, key -> new ModulePackageName(packageName, getModuleSignature(moduleName)));
   }
 
   public ModulePackageName getPackageName(
       @Nonnull final String packageName, @Nonnull final ModuleSignature moduleSignature) {
     String fqId = moduleSignature.getModuleName() + "." + packageName;
-    ModulePackageName packageSignature = (ModulePackageName) packages.get(fqId);
-    if (packageSignature == null) {
-      packageSignature = new ModulePackageName(packageName, moduleSignature);
-      packages.put(fqId, packageSignature);
-    }
-    return packageSignature;
+    return (ModulePackageName) packages.asMap().computeIfAbsent(
+            fqId, key -> new ModulePackageName(packageName, moduleSignature));
   }
 
   /** Wrapper which refers to a given ModuleSignature when building stuff */


### PR DESCRIPTION
Fix #591

According to [guava wiki](https://github.com/google/guava/wiki/MapMakerMigration), I use CacheBuilder instead of MapMaker.