### PR TITLE
Fix resolveOuterClass

### DIFF
--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmAnnotationClassSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmAnnotationClassSource.java
@@ -186,6 +186,9 @@ public class AsmAnnotationClassSource extends JavaAnnotationSootClassSource {
 
   @Nonnull
   public Optional<? extends ClassType> resolveOuterClass() {
+    if (classNode.outerClass == null) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(AsmUtil.toJimpleClassType(classNode.outerClass));
   }
 

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmAnnotationClassSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmAnnotationClassSource.java
@@ -189,7 +189,7 @@ public class AsmAnnotationClassSource extends JavaAnnotationSootClassSource {
     if (classNode.outerClass == null) {
       return Optional.empty();
     }
-    return Optional.ofNullable(AsmUtil.toJimpleClassType(classNode.outerClass));
+    return Optional.of(AsmUtil.toJimpleClassType(classNode.outerClass));
   }
 
   @Nonnull

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmClassSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmClassSource.java
@@ -170,7 +170,7 @@ class AsmClassSource extends JavaSootClassSource {
     if (classNode.outerClass == null) {
       return Optional.empty();
     }
-    return Optional.ofNullable(AsmUtil.toJimpleClassType(classNode.outerClass));
+    return Optional.of(AsmUtil.toJimpleClassType(classNode.outerClass));
   }
 
   @Nonnull

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmClassSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmClassSource.java
@@ -167,6 +167,9 @@ class AsmClassSource extends JavaSootClassSource {
 
   @Nonnull
   public Optional<? extends ClassType> resolveOuterClass() {
+    if (classNode.outerClass == null) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(AsmUtil.toJimpleClassType(classNode.outerClass));
   }
 


### PR DESCRIPTION
Previously, if a class has no outer class, it will cause a NullPointerException.

This PR fixes the problem mentioned above.