### PR TITLE
Improve/unify identifier factory references

### DIFF
--- a/sootup.core/src/main/java/sootup/core/Language.java
+++ b/sootup.core/src/main/java/sootup/core/Language.java
@@ -27,9 +27,15 @@ package sootup.core;
  * @author Markus Schmidt
  */
 public abstract class Language {
+
   public abstract String getName();
 
   public abstract int getVersion();
 
   public abstract IdentifierFactory getIdentifierFactory();
+
+  @Override
+  public String toString() {
+    return getName() + " " + getVersion();
+  }
 }

--- a/sootup.core/src/main/java/sootup/core/Project.java
+++ b/sootup.core/src/main/java/sootup/core/Project.java
@@ -43,8 +43,6 @@ import sootup.core.views.View;
  */
 public abstract class Project<S extends SootClass<?>, V extends View<? extends SootClass<?>>> {
 
-  @Nonnull private final IdentifierFactory identifierFactory;
-
   @Nonnull private final List<AnalysisInputLocation<? extends S>> inputLocations;
   @Nonnull private final SourceTypeSpecifier sourceTypeSpecifier;
   @Nonnull private final Language language;
@@ -59,11 +57,7 @@ public abstract class Project<S extends SootClass<?>, V extends View<? extends S
       @Nonnull Language language,
       @Nonnull AnalysisInputLocation<? extends S> inputLocation,
       @Nonnull SourceTypeSpecifier sourceTypeSpecifier) {
-    this(
-        language,
-        Collections.singletonList(inputLocation),
-        language.getIdentifierFactory(),
-        sourceTypeSpecifier);
+    this(language, Collections.singletonList(inputLocation), sourceTypeSpecifier);
   }
 
   /**
@@ -71,13 +65,11 @@ public abstract class Project<S extends SootClass<?>, V extends View<? extends S
    *
    * @param language the language
    * @param inputLocations the input locations
-   * @param identifierFactory the identifier factory
    * @param sourceTypeSpecifier the source type specifier
    */
   public Project(
       @Nonnull Language language,
       @Nonnull List<AnalysisInputLocation<? extends S>> inputLocations,
-      @Nonnull IdentifierFactory identifierFactory,
       @Nonnull SourceTypeSpecifier sourceTypeSpecifier) {
     this.language = language;
     List<AnalysisInputLocation<? extends S>> unmodifiableInputLocations =
@@ -85,7 +77,6 @@ public abstract class Project<S extends SootClass<?>, V extends View<? extends S
 
     this.sourceTypeSpecifier = sourceTypeSpecifier;
     this.inputLocations = unmodifiableInputLocations;
-    this.identifierFactory = identifierFactory;
   }
 
   public void validate() {
@@ -106,7 +97,7 @@ public abstract class Project<S extends SootClass<?>, V extends View<? extends S
 
   @Nonnull
   public IdentifierFactory getIdentifierFactory() {
-    return this.identifierFactory;
+    return language.getIdentifierFactory();
   }
 
   @Nonnull

--- a/sootup.core/src/main/java/sootup/core/jimple/common/expr/JNegExpr.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/common/expr/JNegExpr.java
@@ -69,17 +69,18 @@ public final class JNegExpr extends AbstractUnopExpr implements Copyable {
   public Type getType() {
     Value op = getOp();
 
-    if (op.getType().equals(PrimitiveType.getInt())
-        || op.getType().equals(PrimitiveType.getByte())
-        || op.getType().equals(PrimitiveType.getShort())
-        || op.getType().equals(PrimitiveType.getBoolean())
-        || op.getType().equals(PrimitiveType.getChar())) {
+    // TODO ms: create a TypeVisitor for this -> O(1)
+    if (op.getType() == PrimitiveType.getInt()
+        || op.getType() == PrimitiveType.getByte()
+        || op.getType() == PrimitiveType.getShort()
+        || op.getType() == PrimitiveType.getBoolean()
+        || op.getType() == PrimitiveType.getChar()) {
       return PrimitiveType.getInt();
-    } else if (op.getType().equals(PrimitiveType.getLong())) {
+    } else if (op.getType() == PrimitiveType.getLong()) {
       return PrimitiveType.getLong();
-    } else if (op.getType().equals(PrimitiveType.getDouble())) {
+    } else if (op.getType() == PrimitiveType.getDouble()) {
       return PrimitiveType.getDouble();
-    } else if (op.getType().equals(PrimitiveType.getFloat())) {
+    } else if (op.getType() == PrimitiveType.getFloat()) {
       return PrimitiveType.getFloat();
     } else {
       return UnknownType.getInstance();

--- a/sootup.core/src/main/java/sootup/core/views/AbstractView.java
+++ b/sootup.core/src/main/java/sootup/core/views/AbstractView.java
@@ -22,8 +22,6 @@ package sootup.core.views;
  * #L%
  */
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -46,8 +44,6 @@ import sootup.core.typehierarchy.ViewTypeHierarchy;
 public abstract class AbstractView<T extends SootClass<?>> implements View<T> {
 
   @Nonnull private final Project<T, ? extends View<T>> project;
-
-  @Nonnull private final Map<ModuleDataKey<?>, Object> moduleData = new HashMap<>();
 
   @Nullable private TypeHierarchy typeHierarchy;
 
@@ -103,18 +99,6 @@ public abstract class AbstractView<T extends SootClass<?>> implements View<T> {
       return Optional.empty();
     }
     return aClass.get().getField(signature.getSubSignature());
-  }
-
-  @SuppressWarnings("unchecked") // Safe because we only put T in putModuleData
-  @Override
-  @Nullable
-  public <K> K getModuleData(@Nonnull ModuleDataKey<K> key) {
-    return (K) moduleData.get(key);
-  }
-
-  @Override
-  public <K> void putModuleData(@Nonnull ModuleDataKey<K> key, @Nonnull K value) {
-    moduleData.put(key, value);
   }
 
   @Override

--- a/sootup.core/src/main/java/sootup/core/views/View.java
+++ b/sootup.core/src/main/java/sootup/core/views/View.java
@@ -25,14 +25,10 @@ package sootup.core.views;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import sootup.core.IdentifierFactory;
 import sootup.core.Project;
 import sootup.core.Scope;
-import sootup.core.frontend.ResolveException;
 import sootup.core.inputlocation.AnalysisInputLocation;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootField;
@@ -90,59 +86,7 @@ public interface View<T extends SootClass> {
   @Nonnull
   default T getClassOrThrow(@Nonnull ClassType classType) {
     return getClass(classType)
-        .orElseThrow(() -> new ResolveException("Could not find " + classType + " in View."));
+        .orElseThrow(
+            () -> new IllegalArgumentException("Could not find " + classType + " in View."));
   }
-
-  /** @see ModuleDataKey */
-  <K> void putModuleData(@Nonnull ModuleDataKey<K> key, @Nonnull K value);
-
-  /** @see ModuleDataKey */
-  @Nullable
-  <K> K getModuleData(@Nonnull ModuleDataKey<K> key);
-
-  /**
-   * @see java.util.Map#computeIfAbsent(Object, Function)
-   * @see ModuleDataKey
-   */
-  default <K> K computeModuleDataIfAbsent(@Nonnull ModuleDataKey<K> key, Supplier<K> dataSupplier) {
-    K moduleData = getModuleData(key);
-    if (moduleData != null) {
-      return moduleData;
-    }
-
-    K computedModuleData = dataSupplier.get();
-    putModuleData(key, computedModuleData);
-    return computedModuleData;
-  }
-
-  /**
-   * A key for use with {@link #getModuleData(ModuleDataKey)}, {@link #putModuleData(ModuleDataKey,
-   * Object)} and {@link #computeModuleDataIfAbsent(ModuleDataKey, Supplier)}. This allows
-   * additional data to be stored or cached inside a {@link View} and to be retrieved in a type-safe
-   * manner. A {@link ModuleDataKey} of type <code>T</code> can only be used to store and retrieve
-   * data of type <code>T</code>.
-   *
-   * <p>Additionally, since it is an abstract class and not an interface, it can be assured that a
-   * given class can only be a key for a single type, which avoids clashes.
-   *
-   * <p>Example: <br>
-   * <br>
-   *
-   * <pre>
-   *   class StringDataKey extends ModuleDataKey&lt;String&gt; {
-   *     public static final StringDataKey instance = new StringDataKey();
-   *     private StringDataKey() {}
-   *   }
-   *
-   *   void storeInView(String str, View view) {
-   *     view.putModuleData(StringDataKey.instance, str);
-   *     String retrieved = view.getModuleData(StringDataKey.instance);
-   *   }
-   * </pre>
-   *
-   * @param <K> The type of the stored and retrieved data that is associated with the key
-   * @author Christian Brüggemann
-   */
-  @SuppressWarnings("unused") // Used in modules
-  abstract class ModuleDataKey<K> {}
 }

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmMethodSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmMethodSource.java
@@ -139,17 +139,8 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
 
   @Nonnull private final Map<LabelNode, Stmt> labelsToStmt = new HashMap<>();
 
-  // FIXME: [ms] or JavaModuleIdentifierFactory if needed..
-  private JavaIdentifierFactory javaIdentifierFactory = JavaIdentifierFactory.getInstance();
-  private final Supplier<MethodSignature> lazyMethodSignature =
-      Suppliers.memoize(
-          () -> {
-            List<Type> sigTypes = AsmUtil.toJimpleSignatureDesc(desc);
-            Type retType = sigTypes.remove(sigTypes.size() - 1);
-
-            return javaIdentifierFactory.getMethodSignature(
-                declaringClass, name, retType, sigTypes);
-          });
+  private final JavaIdentifierFactory identifierFactory;
+  private final Supplier<MethodSignature> lazyMethodSignature;
 
   AsmMethodSource(
       int access,
@@ -162,6 +153,16 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
     super(AsmUtil.SUPPORTED_ASM_OPCODE, null, access, name, desc, signature, exceptions);
     this.bodyInterceptors = bodyInterceptors;
     this.view = view;
+
+    identifierFactory = (JavaIdentifierFactory) view.getIdentifierFactory();
+    lazyMethodSignature =
+        Suppliers.memoize(
+            () -> {
+              List<Type> sigTypes = AsmUtil.toJimpleSignatureDesc(desc);
+              Type retType = sigTypes.remove(sigTypes.size() - 1);
+
+              return identifierFactory.getMethodSignature(declaringClass, name, retType, sigTypes);
+            });
   }
 
   @Override
@@ -396,17 +397,16 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
     Operand opr;
     Type type;
     if (out == null) {
-      JavaClassType declClass =
-          javaIdentifierFactory.getClassType(AsmUtil.toQualifiedName(insn.owner));
+      JavaClassType declClass = identifierFactory.getClassType(AsmUtil.toQualifiedName(insn.owner));
       type = AsmUtil.toJimpleType(insn.desc);
       JFieldRef val;
       FieldSignature ref;
       if (insn.getOpcode() == GETSTATIC) {
-        ref = javaIdentifierFactory.getFieldSignature(insn.name, declClass, type);
+        ref = identifierFactory.getFieldSignature(insn.name, declClass, type);
         val = Jimple.newStaticFieldRef(ref);
       } else {
         Operand base = operandStack.popLocal();
-        ref = javaIdentifierFactory.getFieldSignature(insn.name, declClass, type);
+        ref = identifierFactory.getFieldSignature(insn.name, declClass, type);
         val = Jimple.newInstanceFieldRef((Local) base.stackOrValue(), ref);
         frame.setIn(base);
       }
@@ -429,20 +429,19 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
     Operand opr, rvalue;
     Type type;
     if (out == null) {
-      JavaClassType declClass =
-          javaIdentifierFactory.getClassType(AsmUtil.toQualifiedName(insn.owner));
+      JavaClassType declClass = identifierFactory.getClassType(AsmUtil.toQualifiedName(insn.owner));
       type = AsmUtil.toJimpleType(insn.desc);
 
       JFieldRef val;
       FieldSignature ref;
       rvalue = operandStack.popImmediate(type);
       if (notInstance) {
-        ref = javaIdentifierFactory.getFieldSignature(insn.name, declClass, type);
+        ref = identifierFactory.getFieldSignature(insn.name, declClass, type);
         val = Jimple.newStaticFieldRef(ref);
         frame.setIn(rvalue);
       } else {
         Operand base = operandStack.popLocal();
-        ref = javaIdentifierFactory.getFieldSignature(insn.name, declClass, type);
+        ref = identifierFactory.getFieldSignature(insn.name, declClass, type);
         val = Jimple.newInstanceFieldRef((Local) base.stackOrValue(), ref);
         frame.setIn(rvalue, base);
       }
@@ -1162,11 +1161,11 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
 
   private JFieldRef toSootFieldRef(Handle methodHandle) {
     String bsmClsName = AsmUtil.toQualifiedName(methodHandle.getOwner());
-    JavaClassType bsmCls = javaIdentifierFactory.getClassType(bsmClsName);
+    JavaClassType bsmCls = identifierFactory.getClassType(bsmClsName);
     Type t = AsmUtil.toJimpleSignatureDesc(methodHandle.getDesc()).get(0);
     int kind = methodHandle.getTag();
     FieldSignature fieldSignature =
-        javaIdentifierFactory.getFieldSignature(methodHandle.getName(), bsmCls, t);
+        identifierFactory.getFieldSignature(methodHandle.getName(), bsmCls, t);
     if (kind == MethodHandle.Kind.REF_GET_FIELD_STATIC.getValue()
         || kind == MethodHandle.Kind.REF_PUT_FIELD_STATIC.getValue()) {
       return Jimple.newStaticFieldRef(fieldSignature);
@@ -1178,7 +1177,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
 
   private MethodSignature toMethodSignature(Handle methodHandle) {
     String bsmClsName = AsmUtil.toQualifiedName(methodHandle.getOwner());
-    JavaClassType bsmCls = javaIdentifierFactory.getClassType(bsmClsName);
+    JavaClassType bsmCls = identifierFactory.getClassType(bsmClsName);
     List<Type> bsmSigTypes = AsmUtil.toJimpleSignatureDesc(methodHandle.getDesc());
     Type returnType = bsmSigTypes.remove(bsmSigTypes.size() - 1);
     return JavaIdentifierFactory.getInstance()
@@ -1223,11 +1222,11 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
       if (clsName.charAt(0) == '[') {
         clsName = "java.lang.Object";
       }
-      JavaClassType cls = javaIdentifierFactory.getClassType(AsmUtil.toQualifiedName(clsName));
+      JavaClassType cls = identifierFactory.getClassType(AsmUtil.toQualifiedName(clsName));
       List<Type> sigTypes = AsmUtil.toJimpleSignatureDesc(insn.desc);
       returnType = sigTypes.remove((sigTypes.size() - 1));
       MethodSignature methodSignature =
-          javaIdentifierFactory.getMethodSignature(cls, insn.name, returnType, sigTypes);
+          identifierFactory.getMethodSignature(cls, insn.name, returnType, sigTypes);
       int nrArgs = sigTypes.size();
       final Operand[] args;
       List<Immediate> argList = Collections.emptyList();
@@ -1341,7 +1340,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
 
       // create ref to actual method
       JavaClassType bclass =
-          javaIdentifierFactory.getClassType(JDynamicInvokeExpr.INVOKEDYNAMIC_DUMMY_CLASS_NAME);
+          identifierFactory.getClassType(JDynamicInvokeExpr.INVOKEDYNAMIC_DUMMY_CLASS_NAME);
 
       // Generate parameters & returnType & parameterTypes
       List<Type> types = AsmUtil.toJimpleSignatureDesc(insn.desc);
@@ -1366,7 +1365,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
       // we always model invokeDynamic method refs as static method references
       // of methods on the type SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME
       MethodSignature methodSig =
-          javaIdentifierFactory.getMethodSignature(bclass, insn.name, returnType, parameterTypes);
+          identifierFactory.getMethodSignature(bclass, insn.name, returnType, parameterTypes);
 
       JDynamicInvokeExpr indy =
           Jimple.newDynamicInvokeExpr(
@@ -1941,7 +1940,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
       // used..
       final String exceptionName =
           (trycatch.type != null) ? AsmUtil.toQualifiedName(trycatch.type) : "java.lang.Throwable";
-      JavaClassType exceptionType = javaIdentifierFactory.getClassType(exceptionName);
+      JavaClassType exceptionType = identifierFactory.getClassType(exceptionName);
 
       Trap trap =
           Jimple.newTrap(

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/EmptySwitchEliminator.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/EmptySwitchEliminator.java
@@ -20,9 +20,9 @@ package sootup.java.bytecode.interceptors;
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
+import java.util.ArrayList;
 import javax.annotation.Nonnull;
 import sootup.core.jimple.Jimple;
-import sootup.core.jimple.basic.StmtPositionInfo;
 import sootup.core.jimple.common.stmt.JGotoStmt;
 import sootup.core.jimple.common.stmt.Stmt;
 import sootup.core.jimple.javabytecode.stmt.JSwitchStmt;
@@ -42,15 +42,13 @@ public class EmptySwitchEliminator implements BodyInterceptor {
   @Override
   public void interceptBody(@Nonnull Body.BodyBuilder builder, @Nonnull View<?> view) {
     // Iterate all stmts in the body
-
-    for (Stmt stmt : builder.getStmtGraph()) {
+    for (Stmt stmt : new ArrayList<>(builder.getStmtGraph().getNodes())) {
       // If the observed stmt an instance of JSwitchStmt
       if (stmt instanceof JSwitchStmt) {
         JSwitchStmt sw = (JSwitchStmt) stmt;
         // if there's only default case
         if (sw.getValueCount() == 1) {
-          StmtPositionInfo positionInfo = sw.getPositionInfo();
-          JGotoStmt gotoStmt = Jimple.newGotoStmt(positionInfo);
+          JGotoStmt gotoStmt = Jimple.newGotoStmt(sw.getPositionInfo());
           builder.replaceStmt(sw, gotoStmt);
         }
       }

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaProject.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaProject.java
@@ -49,7 +49,7 @@ public class JavaProject extends Project<JavaSootClass, JavaView> {
       JavaLanguage language,
       @Nonnull List<AnalysisInputLocation<? extends JavaSootClass>> inputLocations,
       @Nonnull SourceTypeSpecifier sourceTypeSpecifier) {
-    super(language, inputLocations, JavaIdentifierFactory.getInstance(), sourceTypeSpecifier);
+    super(language, inputLocations, sourceTypeSpecifier);
   }
 
   @Nonnull

--- a/sootup.java.core/src/main/java/sootup/java/core/language/JavaLanguage.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/language/JavaLanguage.java
@@ -28,7 +28,6 @@ import sootup.core.Language;
 import sootup.java.core.JavaIdentifierFactory;
 import sootup.java.core.JavaModuleIdentifierFactory;
 
-// TODO: Auto-generated Javadoc
 /**
  * Language specific Configuration for Java.
  *
@@ -40,7 +39,7 @@ public class JavaLanguage extends Language {
   /** The identifier factory. */
   @Nonnull private final IdentifierFactory identifierFactory;
 
-  /** The version number. */
+  /** The version number of Java. */
   private final int version;
 
   /**

--- a/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleProject.java
+++ b/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleProject.java
@@ -3,7 +3,6 @@ package sootup.jimple.parser;
 import java.util.List;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
-import sootup.core.IdentifierFactory;
 import sootup.core.Project;
 import sootup.core.SourceTypeSpecifier;
 import sootup.core.cache.provider.ClassCacheProvider;
@@ -19,11 +18,7 @@ public class JimpleProject extends Project<SootClass<?>, JimpleView> {
   }
 
   public JimpleProject(@Nonnull List<AnalysisInputLocation<? extends SootClass<?>>> inputLocation) {
-    super(
-        JimpleLanguage.getInstance(),
-        inputLocation,
-        JimpleLanguage.getInstance().getIdentifierFactory(),
-        DefaultSourceTypeSpecifier.getInstance());
+    super(JimpleLanguage.getInstance(), inputLocation, DefaultSourceTypeSpecifier.getInstance());
   }
 
   public JimpleProject(
@@ -34,9 +29,8 @@ public class JimpleProject extends Project<SootClass<?>, JimpleView> {
 
   public JimpleProject(
       @Nonnull List<AnalysisInputLocation<? extends SootClass<?>>> inputLocations,
-      @Nonnull IdentifierFactory identifierFactory,
       @Nonnull SourceTypeSpecifier sourceTypeSpecifier) {
-    super(JimpleLanguage.getInstance(), inputLocations, identifierFactory, sourceTypeSpecifier);
+    super(JimpleLanguage.getInstance(), inputLocations, sourceTypeSpecifier);
   }
 
   @Nonnull


### PR DESCRIPTION
`Project` stored the `IdentifierFactory` reference via Language field *and* as a dedicated field.
Now only the Language is used to store it.