### PR TITLE
Split Modifiers to resolve flag clashes

### DIFF
--- a/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
 import sootup.core.jimple.common.expr.AbstractInvokeExpr;
 import sootup.core.jimple.common.expr.JDynamicInvokeExpr;
 import sootup.core.jimple.common.expr.JSpecialInvokeExpr;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -89,7 +89,7 @@ public class ClassHierarchyAnalysisAlgorithm extends AbstractCallGraphAlgorithm 
             .orElseGet(() -> findMethodInHierarchy(view, targetMethodSignature));
 
     if (targetMethod == null
-        || Modifier.isStatic(targetMethod.getModifiers())
+        || MethodModifier.isStatic(targetMethod.getModifiers())
         || (invokeExpr instanceof JSpecialInvokeExpr)) {
       return result;
     } else {

--- a/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
@@ -31,7 +31,7 @@ import sootup.core.jimple.common.expr.AbstractInvokeExpr;
 import sootup.core.jimple.common.expr.JNewExpr;
 import sootup.core.jimple.common.expr.JSpecialInvokeExpr;
 import sootup.core.jimple.common.stmt.JAssignStmt;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -138,7 +138,7 @@ public class RapidTypeAnalysisAlgorithm extends AbstractCallGraphAlgorithm {
             .orElseGet(() -> findMethodInHierarchy(view, targetMethodSignature));
 
     if (targetMethod == null
-        || Modifier.isStatic(targetMethod.getModifiers())
+        || MethodModifier.isStatic(targetMethod.getModifiers())
         || (invokeExpr instanceof JSpecialInvokeExpr)) {
       return result;
     } else {

--- a/sootup.core/src/main/java/sootup/core/frontend/BodySource.java
+++ b/sootup.core/src/main/java/sootup/core/frontend/BodySource.java
@@ -24,7 +24,7 @@ package sootup.core.frontend;
 import java.io.IOException;
 import javax.annotation.Nonnull;
 import sootup.core.model.Body;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.signatures.MethodSignature;
 
 /**
@@ -40,7 +40,8 @@ public interface BodySource {
    *     body accordingly.
    */
   @Nonnull
-  Body resolveBody(@Nonnull Iterable<Modifier> modifiers) throws ResolveException, IOException;
+  Body resolveBody(@Nonnull Iterable<MethodModifier> modifiers)
+      throws ResolveException, IOException;
 
   /** @return returns the default value of the Annotation for this method */
   Object resolveAnnotationsDefaultValue();

--- a/sootup.core/src/main/java/sootup/core/frontend/OverridingBodySource.java
+++ b/sootup.core/src/main/java/sootup/core/frontend/OverridingBodySource.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import sootup.core.model.Body;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.signatures.MethodSignature;
 
 /** @author Hasitha Rajapakse */
@@ -68,7 +68,7 @@ public class OverridingBodySource implements BodySource {
 
   @Nonnull
   @Override
-  public Body resolveBody(@Nonnull Iterable<Modifier> modifiers) throws IOException {
+  public Body resolveBody(@Nonnull Iterable<MethodModifier> modifiers) throws IOException {
     return body != null ? body : delegate.resolveBody(modifiers);
   }
 

--- a/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java
+++ b/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java
@@ -53,7 +53,7 @@ public class OverridingClassSource extends SootClassSource {
 
   @Nullable private final Collection<SootMethod> overriddenSootMethods;
   @Nullable private final Collection<SootField> overriddenSootFields;
-  @Nullable private final Set<Modifier> overriddenModifiers;
+  @Nullable private final Set<ClassModifier> overriddenModifiers;
   @Nullable private final Set<ClassType> overriddenInterfaces;
   @Nullable private final Optional<ClassType> overriddenSuperclass;
   @Nullable private final Optional<ClassType> overriddenOuterClass;
@@ -76,7 +76,7 @@ public class OverridingClassSource extends SootClassSource {
   private OverridingClassSource(
       @Nullable Collection<SootMethod> overriddenSootMethods,
       @Nullable Collection<SootField> overriddenSootFields,
-      @Nullable Set<Modifier> overriddenModifiers,
+      @Nullable Set<ClassModifier> overriddenModifiers,
       @Nullable Set<ClassType> overriddenInterfaces,
       @Nullable Optional<ClassType> overriddenSuperclass,
       @Nullable Optional<ClassType> overriddenOuterClass,
@@ -97,7 +97,7 @@ public class OverridingClassSource extends SootClassSource {
   public OverridingClassSource(
       @Nonnull Set<SootMethod> sootMethods,
       @Nonnull Set<SootField> sootFields,
-      @Nonnull EnumSet<Modifier> modifiers,
+      @Nonnull EnumSet<ClassModifier> modifiers,
       @Nonnull Set<ClassType> interfaces,
       @Nonnull ClassType superClass,
       @Nonnull ClassType outerClass,
@@ -131,7 +131,7 @@ public class OverridingClassSource extends SootClassSource {
 
   @Nonnull
   @Override
-  public Set<Modifier> resolveModifiers() {
+  public Set<ClassModifier> resolveModifiers() {
     return overriddenModifiers != null ? overriddenModifiers : delegate.resolveModifiers();
   }
 
@@ -261,7 +261,7 @@ public class OverridingClassSource extends SootClassSource {
   }
 
   @Nonnull
-  public OverridingClassSource withModifiers(@Nonnull Set<Modifier> overriddenModifiers) {
+  public OverridingClassSource withModifiers(@Nonnull Set<ClassModifier> overriddenModifiers) {
     return new OverridingClassSource(
         overriddenSootMethods,
         overriddenSootFields,

--- a/sootup.core/src/main/java/sootup/core/frontend/SootClassSource.java
+++ b/sootup.core/src/main/java/sootup/core/frontend/SootClassSource.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import sootup.core.inputlocation.AnalysisInputLocation;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.Position;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootField;
@@ -78,7 +78,7 @@ public abstract class SootClassSource<S extends SootClass<? extends SootClassSou
 
   /** Reads from the source to retrieve its modifiers. This may be an expensive operation. */
   @Nonnull
-  public abstract Set<Modifier> resolveModifiers();
+  public abstract Set<ClassModifier> resolveModifiers();
 
   /**
    * Reads from the source to retrieve its directly implemented interfaces. This may be an expensive

--- a/sootup.core/src/main/java/sootup/core/model/Body.java
+++ b/sootup.core/src/main/java/sootup/core/model/Body.java
@@ -341,7 +341,7 @@ public class Body implements Copyable {
     return new BodyBuilder(graph);
   }
 
-  public static BodyBuilder builder(@Nonnull Body body, Set<Modifier> modifiers) {
+  public static BodyBuilder builder(@Nonnull Body body, Set<MethodModifier> modifiers) {
     return new BodyBuilder(body, modifiers);
   }
 
@@ -366,7 +366,7 @@ public class Body implements Copyable {
   public static class BodyBuilder {
     @Nonnull private Set<Local> locals = new LinkedHashSet<>();
     @Nonnull private final LocalGenerator localGen = new LocalGenerator(locals);
-    @Nonnull private Set<Modifier> modifiers = Collections.emptySet();
+    @Nonnull private Set<MethodModifier> modifiers = Collections.emptySet();
 
     @Nullable private Position position = null;
     @Nonnull private final MutableStmtGraph graph;
@@ -382,7 +382,7 @@ public class Body implements Copyable {
       this.graph = graph;
     }
 
-    BodyBuilder(@Nonnull Body body, @Nonnull Set<Modifier> modifiers) {
+    BodyBuilder(@Nonnull Body body, @Nonnull Set<MethodModifier> modifiers) {
       setModifiers(modifiers);
       setMethodSignature(body.getMethodSignature());
       setLocals(new LinkedHashSet<>(body.getLocals()));
@@ -510,7 +510,7 @@ public class Body implements Copyable {
       return this;
     }
 
-    public BodyBuilder setModifiers(@Nonnull Set<Modifier> modifiers) {
+    public BodyBuilder setModifiers(@Nonnull Set<MethodModifier> modifiers) {
       this.modifiers = modifiers;
       return this;
     }
@@ -567,7 +567,7 @@ public class Body implements Copyable {
     }
 
     @Nonnull
-    public Set<Modifier> getModifiers() {
+    public Set<MethodModifier> getModifiers() {
       return modifiers;
     }
 

--- a/sootup.core/src/main/java/sootup/core/model/ClassModifier.java
+++ b/sootup.core/src/main/java/sootup/core/model/ClassModifier.java
@@ -1,0 +1,168 @@
+// Incomplete class
+
+package sootup.core.model;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997-2020 Raja Vallee-Rai, Jan Martin Persch, Christian Brüggemann and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+/**
+ * An Enum that provides static methods and constants to represent and work with with Java modifiers
+ * (ie public, final,...) Represents Java modifiers that can be packed and combined via EnumSet and
+ * methods to query these.
+ */
+public enum ClassModifier {
+  PUBLIC(0x0001),
+  PRIVATE(0x0002),
+  PROTECTED(0x0004),
+
+  STATIC(0x0008),
+  FINAL(0x0010),
+
+  SUPER(0x0020),
+  INTERFACE(0x0200),
+  ABSTRACT(0x0400),
+  SYNTHETIC(0x1000),
+  ANNOTATION(0x2000),
+  ENUM(0x4000),
+
+  MODULE(0x8000);
+
+  private final int bytecode;
+
+  ClassModifier(int i) {
+    bytecode = i;
+  }
+
+  public static boolean isAbstract(@Nonnull Set<ClassModifier> m) {
+    return m.contains(ABSTRACT);
+  }
+
+  public static boolean isFinal(@Nonnull Set<ClassModifier> m) {
+    return m.contains(FINAL);
+  }
+
+  public static boolean isInterface(@Nonnull Set<ClassModifier> m) {
+    return m.contains(INTERFACE);
+  }
+
+  public static boolean isPrivate(@Nonnull Set<ClassModifier> m) {
+    return m.contains(PRIVATE);
+  }
+
+  public static boolean isProtected(@Nonnull Set<ClassModifier> m) {
+    return m.contains(PROTECTED);
+  }
+
+  public static boolean isPublic(@Nonnull Set<ClassModifier> m) {
+    return m.contains(PUBLIC);
+  }
+
+  public static boolean isStatic(@Nonnull Set<ClassModifier> m) {
+    return m.contains(STATIC);
+  }
+
+  public static boolean isSuper(@Nonnull Set<ClassModifier> m) {
+    return m.contains(SUPER);
+  }
+
+  public static boolean isAnnotation(@Nonnull Set<ClassModifier> m) {
+    return m.contains(ANNOTATION);
+  }
+
+  public static boolean isEnum(@Nonnull Set<ClassModifier> m) {
+    return m.contains(ENUM);
+  }
+
+  public static boolean isSynthetic(@Nonnull Set<ClassModifier> m) {
+    return m.contains(SYNTHETIC);
+  }
+
+  /**
+   * Converts the given modifiers to their string representation, in canonical form.
+   *
+   * @param m a modifier set
+   * @return a textual representation of the modifiers.
+   */
+  @Nonnull
+  public static String toString(@Nonnull Set<ClassModifier> m) {
+    StringBuilder builder = new StringBuilder();
+
+    if (isPublic(m)) {
+      builder.append("public ");
+    } else if (isPrivate(m)) {
+      builder.append("private ");
+    } else if (isProtected(m)) {
+      builder.append("protected ");
+    }
+
+    if (isAbstract(m)) {
+      builder.append("abstract ");
+    }
+
+    if (isStatic(m)) {
+      builder.append("static ");
+    }
+
+    if (isFinal(m)) {
+      builder.append("final ");
+    }
+
+    if (isSuper(m)) {
+      builder.append("super ");
+    }
+
+    if (isAnnotation(m)) {
+      builder.append("annotation ");
+    }
+
+    if (isEnum(m)) {
+      builder.append("enum ");
+    }
+
+    if (isInterface(m)) {
+      builder.append("interface ");
+    }
+
+    // trim
+    final int lastCharPos = builder.length() - 1;
+    if (lastCharPos > 0) {
+      builder.setLength(lastCharPos);
+    }
+    return builder.toString();
+  }
+
+  @Nonnull
+  // depends on the natural order of the Enums!
+  public static String toString(@Nonnull EnumSet<ClassModifier> m) {
+    return m.stream().map((mod) -> mod.name().toLowerCase()).collect(Collectors.joining(" "));
+  }
+
+  /** @return the bytecode of this Modifier. */
+  public int getBytecode() {
+    return bytecode;
+  }
+}

--- a/sootup.core/src/main/java/sootup/core/model/FieldModifier.java
+++ b/sootup.core/src/main/java/sootup/core/model/FieldModifier.java
@@ -34,103 +34,57 @@ import javax.annotation.Nonnull;
  * (ie public, final,...) Represents Java modifiers that can be packed and combined via EnumSet and
  * methods to query these.
  */
-public enum Modifier {
+public enum FieldModifier {
   PUBLIC(0x0001),
   PRIVATE(0x0002),
   PROTECTED(0x0004),
-
-  ABSTRACT(0x0400),
   STATIC(0x0008),
   FINAL(0x0010),
-
-  SYNCHRONIZED(0x0020),
-  NATIVE(0x0100),
-  TRANSIENT(0x0080), /* VARARGS for methods */
-  VOLATILE(0x0040), /* BRIDGE for methods */
-  STRICTFP(0x0800),
-  ANNOTATION(0x2000),
-  ENUM(0x4000),
-  INTERFACE(0x0200),
-
-  MODULE(0x8000),
-
-  // dex specifific modifiers
+  VOLATILE(0x0040),
+  TRANSIENT(0x0080),
   SYNTHETIC(0x1000),
-  CONSTRUCTOR(0x10000),
-  DECLARED_SYNCHRONIZED(0x20000);
+  ENUM(0x4000);
 
   private final int bytecode;
 
-  Modifier(int i) {
+  FieldModifier(int i) {
     bytecode = i;
   }
 
-  public static boolean isAbstract(@Nonnull Set<Modifier> m) {
-    return m.contains(ABSTRACT);
-  }
-
-  public static boolean isFinal(@Nonnull Set<Modifier> m) {
+  public static boolean isFinal(@Nonnull Set<FieldModifier> m) {
     return m.contains(FINAL);
   }
 
-  public static boolean isInterface(@Nonnull Set<Modifier> m) {
-    return m.contains(INTERFACE);
-  }
-
-  public static boolean isNative(@Nonnull Set<Modifier> m) {
-    return m.contains(NATIVE);
-  }
-
-  public static boolean isPrivate(@Nonnull Set<Modifier> m) {
+  public static boolean isPrivate(@Nonnull Set<FieldModifier> m) {
     return m.contains(PRIVATE);
   }
 
-  public static boolean isProtected(@Nonnull Set<Modifier> m) {
+  public static boolean isProtected(@Nonnull Set<FieldModifier> m) {
     return m.contains(PROTECTED);
   }
 
-  public static boolean isPublic(@Nonnull Set<Modifier> m) {
+  public static boolean isPublic(@Nonnull Set<FieldModifier> m) {
     return m.contains(PUBLIC);
   }
 
-  public static boolean isStatic(@Nonnull Set<Modifier> m) {
+  public static boolean isStatic(@Nonnull Set<FieldModifier> m) {
     return m.contains(STATIC);
   }
 
-  public static boolean isSynchronized(@Nonnull Set<Modifier> m) {
-    return m.contains(SYNCHRONIZED);
-  }
-
-  public static boolean isTransient(@Nonnull Set<Modifier> m) {
+  public static boolean isTransient(@Nonnull Set<FieldModifier> m) {
     return m.contains(TRANSIENT);
   }
 
-  public static boolean isVolatile(@Nonnull Set<Modifier> m) {
+  public static boolean isVolatile(@Nonnull Set<FieldModifier> m) {
     return m.contains(VOLATILE);
   }
 
-  public static boolean isStrictFP(@Nonnull Set<Modifier> m) {
-    return m.contains(STRICTFP);
-  }
-
-  public static boolean isAnnotation(@Nonnull Set<Modifier> m) {
-    return m.contains(ANNOTATION);
-  }
-
-  public static boolean isEnum(@Nonnull Set<Modifier> m) {
+  public static boolean isEnum(@Nonnull Set<FieldModifier> m) {
     return m.contains(ENUM);
   }
 
-  public static boolean isSynthetic(@Nonnull Set<Modifier> m) {
+  public static boolean isSynthetic(@Nonnull Set<FieldModifier> m) {
     return m.contains(SYNTHETIC);
-  }
-
-  public static boolean isConstructor(@Nonnull Set<Modifier> m) {
-    return m.contains(CONSTRUCTOR);
-  }
-
-  public static boolean isDeclaredSynchronized(@Nonnull Set<Modifier> m) {
-    return m.contains(DECLARED_SYNCHRONIZED);
   }
 
   /**
@@ -140,7 +94,7 @@ public enum Modifier {
    * @return a textual representation of the modifiers.
    */
   @Nonnull
-  public static String toString(@Nonnull Set<Modifier> m) {
+  public static String toString(@Nonnull Set<FieldModifier> m) {
     StringBuilder builder = new StringBuilder();
 
     if (isPublic(m)) {
@@ -151,10 +105,6 @@ public enum Modifier {
       builder.append("protected ");
     }
 
-    if (isAbstract(m)) {
-      builder.append("abstract ");
-    }
-
     if (isStatic(m)) {
       builder.append("static ");
     }
@@ -163,36 +113,16 @@ public enum Modifier {
       builder.append("final ");
     }
 
-    if (isSynchronized(m)) {
-      builder.append("synchronized ");
-    }
-
-    if (isNative(m)) {
-      builder.append("native ");
+    if (isVolatile(m)) {
+      builder.append("volatile ");
     }
 
     if (isTransient(m)) {
       builder.append("transient ");
     }
 
-    if (isVolatile(m)) {
-      builder.append("volatile ");
-    }
-
-    if (isStrictFP(m)) {
-      builder.append("strictfp ");
-    }
-
-    if (isAnnotation(m)) {
-      builder.append("annotation ");
-    }
-
     if (isEnum(m)) {
       builder.append("enum ");
-    }
-
-    if (isInterface(m)) {
-      builder.append("interface ");
     }
 
     // trim
@@ -205,7 +135,7 @@ public enum Modifier {
 
   @Nonnull
   // depends on the natural order of the Enums!
-  public static String toString(@Nonnull EnumSet<Modifier> m) {
+  public static String toString(@Nonnull EnumSet<FieldModifier> m) {
     return m.stream().map((mod) -> mod.name().toLowerCase()).collect(Collectors.joining(" "));
   }
 

--- a/sootup.core/src/main/java/sootup/core/model/MethodModifier.java
+++ b/sootup.core/src/main/java/sootup/core/model/MethodModifier.java
@@ -1,0 +1,197 @@
+// Incomplete class
+
+package sootup.core.model;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997-2020 Raja Vallee-Rai, Jan Martin Persch, Christian Brüggemann and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+/**
+ * An Enum that provides static methods and constants to represent and work with with Java modifiers
+ * (ie public, final,...) Represents Java modifiers that can be packed and combined via EnumSet and
+ * methods to query these.
+ */
+public enum MethodModifier {
+  PUBLIC(0x0001),
+  PRIVATE(0x0002),
+  PROTECTED(0x0004),
+
+  STATIC(0x0008),
+  FINAL(0x0010),
+
+  SYNCHRONIZED(0x0020),
+
+  VARARGS(0x0080), /* VARARGS for methods */
+  BRIDGE(0x0040),
+  NATIVE(0x0100),
+  ABSTRACT(0x0400),
+  STRICTFP(0x0800),
+
+  // dex specifific modifiers
+  SYNTHETIC(0x1000),
+  ENUM(0x4000),
+  CONSTRUCTOR(0x10000),
+  DECLARED_SYNCHRONIZED(0x20000);
+
+  private final int bytecode;
+
+  MethodModifier(int i) {
+    bytecode = i;
+  }
+
+  public static boolean isAbstract(@Nonnull Set<MethodModifier> m) {
+    return m.contains(ABSTRACT);
+  }
+
+  public static boolean isFinal(@Nonnull Set<MethodModifier> m) {
+    return m.contains(FINAL);
+  }
+
+  public static boolean isNative(@Nonnull Set<MethodModifier> m) {
+    return m.contains(NATIVE);
+  }
+
+  public static boolean isPrivate(@Nonnull Set<MethodModifier> m) {
+    return m.contains(PRIVATE);
+  }
+
+  public static boolean isProtected(@Nonnull Set<MethodModifier> m) {
+    return m.contains(PROTECTED);
+  }
+
+  public static boolean isPublic(@Nonnull Set<MethodModifier> m) {
+    return m.contains(PUBLIC);
+  }
+
+  public static boolean isStatic(@Nonnull Set<MethodModifier> m) {
+    return m.contains(STATIC);
+  }
+
+  public static boolean isSynchronized(@Nonnull Set<MethodModifier> m) {
+    return m.contains(SYNCHRONIZED);
+  }
+
+  public static boolean isVarargs(@Nonnull Set<MethodModifier> m) {
+    return m.contains(VARARGS);
+  }
+
+  public static boolean isBridge(@Nonnull Set<MethodModifier> m) {
+    return m.contains(BRIDGE);
+  }
+
+  public static boolean isStrictFP(@Nonnull Set<MethodModifier> m) {
+    return m.contains(STRICTFP);
+  }
+
+  public static boolean isEnum(@Nonnull Set<MethodModifier> m) {
+    return m.contains(ENUM);
+  }
+
+  public static boolean isSynthetic(@Nonnull Set<MethodModifier> m) {
+    return m.contains(SYNTHETIC);
+  }
+
+  public static boolean isConstructor(@Nonnull Set<MethodModifier> m) {
+    return m.contains(CONSTRUCTOR);
+  }
+
+  public static boolean isDeclaredSynchronized(@Nonnull Set<MethodModifier> m) {
+    return m.contains(DECLARED_SYNCHRONIZED);
+  }
+
+  /**
+   * Converts the given modifiers to their string representation, in canonical form.
+   *
+   * @param m a modifier set
+   * @return a textual representation of the modifiers.
+   */
+  @Nonnull
+  public static String toString(@Nonnull Set<MethodModifier> m) {
+    StringBuilder builder = new StringBuilder();
+
+    if (isPublic(m)) {
+      builder.append("public ");
+    } else if (isPrivate(m)) {
+      builder.append("private ");
+    } else if (isProtected(m)) {
+      builder.append("protected ");
+    }
+
+    if (isAbstract(m)) {
+      builder.append("abstract ");
+    }
+
+    if (isStatic(m)) {
+      builder.append("static ");
+    }
+
+    if (isFinal(m)) {
+      builder.append("final ");
+    }
+
+    if (isSynchronized(m)) {
+      builder.append("synchronized ");
+    }
+
+    if (isNative(m)) {
+      builder.append("native ");
+    }
+
+    if (isBridge(m)) {
+      builder.append("bridge ");
+    }
+
+    if (isVarargs(m)) {
+      builder.append("varargs ");
+    }
+
+    if (isStrictFP(m)) {
+      builder.append("strictfp ");
+    }
+
+    if (isEnum(m)) {
+      builder.append("enum ");
+    }
+
+    // trim
+    final int lastCharPos = builder.length() - 1;
+    if (lastCharPos > 0) {
+      builder.setLength(lastCharPos);
+    }
+    return builder.toString();
+  }
+
+  @Nonnull
+  // depends on the natural order of the Enums!
+  public static String toString(@Nonnull EnumSet<MethodModifier> m) {
+    return m.stream().map((mod) -> mod.name().toLowerCase()).collect(Collectors.joining(" "));
+  }
+
+  /** @return the bytecode of this Modifier. */
+  public int getBytecode() {
+    return bytecode;
+  }
+}

--- a/sootup.core/src/main/java/sootup/core/model/SootClass.java
+++ b/sootup.core/src/main/java/sootup/core/model/SootClass.java
@@ -106,12 +106,12 @@ public class SootClass<S extends SootClassSource<? extends SootClass<S>>> extend
     return this._lazyFields.get();
   }
 
-  private final Supplier<Set<Modifier>> lazyModifiers =
+  private final Supplier<Set<ClassModifier>> lazyModifiers =
       Suppliers.memoize(classSource::resolveModifiers);
 
   /** Returns the modifiers of this class in an immutable set. */
   @Nonnull
-  public Set<Modifier> getModifiers() {
+  public Set<ClassModifier> getModifiers() {
     return lazyModifiers.get();
   }
 
@@ -184,17 +184,17 @@ public class SootClass<S extends SootClassSource<? extends SootClass<S>>> extend
 
   /** Convenience method; returns true if this class is an interface. */
   public boolean isInterface() {
-    return Modifier.isInterface(this.getModifiers());
+    return ClassModifier.isInterface(this.getModifiers());
   }
 
   /** Convenience method; returns true if this class is an enumeration. */
   public boolean isEnum() {
-    return Modifier.isEnum(this.getModifiers());
+    return ClassModifier.isEnum(this.getModifiers());
   }
 
   /** Convenience method; returns true if this class is synchronized. */
-  public boolean isSynchronized() {
-    return Modifier.isSynchronized(this.getModifiers());
+  public boolean isSuper() {
+    return ClassModifier.isSuper(this.getModifiers());
   }
 
   /** Returns true if this class is not an interface and not abstract. */
@@ -204,7 +204,7 @@ public class SootClass<S extends SootClassSource<? extends SootClass<S>>> extend
 
   /** Convenience method; returns true if this class is public. */
   public boolean isPublic() {
-    return Modifier.isPublic(this.getModifiers());
+    return ClassModifier.isPublic(this.getModifiers());
   }
 
   /** Returns the name of this class. */
@@ -240,27 +240,27 @@ public class SootClass<S extends SootClassSource<? extends SootClass<S>>> extend
 
   /** Convenience method returning true if this class is private. */
   public boolean isPrivate() {
-    return Modifier.isPrivate(this.getModifiers());
+    return ClassModifier.isPrivate(this.getModifiers());
   }
 
   /** Convenience method returning true if this class is protected. */
   public boolean isProtected() {
-    return Modifier.isProtected(this.getModifiers());
+    return ClassModifier.isProtected(this.getModifiers());
   }
 
   /** Convenience method returning true if this class is abstract. */
   public boolean isAbstract() {
-    return Modifier.isAbstract(this.getModifiers());
+    return ClassModifier.isAbstract(this.getModifiers());
   }
 
   /** Convenience method returning true if this class is final. */
   public boolean isFinal() {
-    return Modifier.isFinal(this.getModifiers());
+    return ClassModifier.isFinal(this.getModifiers());
   }
 
   /** Convenience method returning true if this class is static. */
   public boolean isStatic() {
-    return Modifier.isStatic(this.getModifiers());
+    return ClassModifier.isStatic(this.getModifiers());
   }
 
   private final Supplier<Position> lazyPosition = Suppliers.memoize(classSource::resolvePosition);

--- a/sootup.core/src/main/java/sootup/core/model/SootClassMember.java
+++ b/sootup.core/src/main/java/sootup/core/model/SootClassMember.java
@@ -22,13 +22,9 @@ package sootup.core.model;
  * #L%
  */
 
-import com.google.common.collect.ImmutableSet;
-import java.util.Objects;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import sootup.core.signatures.SootClassMemberSignature;
 import sootup.core.types.ClassType;
-import sootup.core.util.ImmutableUtils;
 
 /**
  * Provides methods common to Soot objects belonging to classes, namely SootField and SootMethod.
@@ -39,13 +35,11 @@ import sootup.core.util.ImmutableUtils;
 public abstract class SootClassMember<S extends SootClassMemberSignature> {
 
   @Nonnull private final S signature;
-  @Nonnull private final ImmutableSet<Modifier> modifiers;
+
   @Nonnull private final Position position;
 
-  SootClassMember(
-      @Nonnull S signature, @Nonnull Iterable<Modifier> modifiers, @Nonnull Position position) {
+  SootClassMember(@Nonnull S signature, @Nonnull Position position) {
     this.signature = signature;
-    this.modifiers = ImmutableUtils.immutableEnumSetOf(modifiers);
     this.position = position;
   }
 
@@ -56,44 +50,22 @@ public abstract class SootClassMember<S extends SootClassMemberSignature> {
   }
 
   /** Convenience method returning true if this class member is protected. */
-  public boolean isProtected() {
-    return Modifier.isProtected(this.getModifiers());
-  }
+  public abstract boolean isProtected();
 
   /** Convenience method returning true if this class member is private. */
-  public boolean isPrivate() {
-    return Modifier.isPrivate(this.getModifiers());
-  }
+  public abstract boolean isPrivate();
 
   /** Convenience method returning true if this class member is public. */
-  public boolean isPublic() {
-    return Modifier.isPublic(this.getModifiers());
-  }
+  public abstract boolean isPublic();
 
   /** Convenience method returning true if this class member is static. */
-  public boolean isStatic() {
-    return Modifier.isStatic(this.getModifiers());
-  }
+  public abstract boolean isStatic();
 
   /** Convenience method returning true if this field is final. */
-  public boolean isFinal() {
-    return Modifier.isFinal(this.getModifiers());
-  }
-
-  /**
-   * Gets the modifiers of this class member in an immutable set.
-   *
-   * @see Modifier
-   */
-  @Nonnull
-  public Set<Modifier> getModifiers() {
-    return modifiers;
-  }
+  public abstract boolean isFinal();
 
   /** Returns a hash code for this method consistent with structural equality. */
-  public int equivHashCode() {
-    return Objects.hash(modifiers, signature);
-  }
+  public abstract int equivHashCode();
 
   /** Returns the signature of this method. */
   @Override

--- a/sootup.core/src/main/java/sootup/core/model/SootField.java
+++ b/sootup.core/src/main/java/sootup/core/model/SootField.java
@@ -21,11 +21,15 @@ package sootup.core.model;
  * #L%
  */
 
+import com.google.common.collect.ImmutableSet;
 import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import sootup.core.jimple.basic.NoPositionInformation;
 import sootup.core.signatures.FieldSignature;
 import sootup.core.types.Type;
+import sootup.core.util.ImmutableUtils;
 
 /**
  * Soot's counterpart of the source language's field concept. Soot representation of a Java field.
@@ -36,12 +40,54 @@ import sootup.core.types.Type;
  */
 public class SootField extends SootClassMember<FieldSignature> implements Field {
 
+  @Nonnull private final ImmutableSet<FieldModifier> modifiers;
   /** Constructs a Soot field with the given name, type and modifiers. */
   public SootField(
       @Nonnull FieldSignature signature,
-      @Nonnull Iterable<Modifier> modifiers,
+      @Nonnull Iterable<FieldModifier> modifiers,
       @Nonnull Position position) {
-    super(signature, modifiers, position);
+    super(signature, position);
+    this.modifiers = ImmutableUtils.immutableEnumSetOf(modifiers);
+  }
+
+  @Override
+  public boolean isProtected() {
+    return FieldModifier.isProtected(this.getModifiers());
+  }
+
+  @Override
+  public boolean isPrivate() {
+    return FieldModifier.isPrivate(this.getModifiers());
+  }
+
+  @Override
+  public boolean isPublic() {
+    return FieldModifier.isPublic(this.getModifiers());
+  }
+
+  @Override
+  public boolean isStatic() {
+    return FieldModifier.isStatic(this.getModifiers());
+  }
+
+  @Override
+  public boolean isFinal() {
+    return FieldModifier.isFinal(this.getModifiers());
+  }
+
+  /**
+   * Gets the modifiers of this class member in an immutable set.
+   *
+   * @see FieldModifier
+   */
+  @Nonnull
+  public Set<FieldModifier> getModifiers() {
+    return modifiers;
+  }
+
+  @Override
+  public int equivHashCode() {
+    return Objects.hash(modifiers, getSignature());
   }
 
   @Nonnull
@@ -54,7 +100,9 @@ public class SootField extends SootClassMember<FieldSignature> implements Field 
     if (this.getModifiers().isEmpty()) {
       return this.getSignature().getSubSignature().toString();
     } else {
-      return Modifier.toString(this.getModifiers()) + ' ' + this.getSignature().getSubSignature();
+      return FieldModifier.toString(this.getModifiers())
+          + ' '
+          + this.getSignature().getSubSignature();
     }
   }
 
@@ -69,7 +117,7 @@ public class SootField extends SootClassMember<FieldSignature> implements Field 
   }
 
   @Nonnull
-  public SootField withModifiers(@Nonnull Iterable<Modifier> modifiers) {
+  public SootField withModifiers(@Nonnull Iterable<FieldModifier> modifiers) {
     return new SootField(getSignature(), modifiers, getPosition());
   }
 
@@ -90,10 +138,10 @@ public class SootField extends SootClassMember<FieldSignature> implements Field 
 
   public interface ModifierStep {
     @Nonnull
-    BuildStep withModifier(@Nonnull Iterable<Modifier> modifier);
+    BuildStep withModifier(@Nonnull Iterable<FieldModifier> modifier);
 
     @Nonnull
-    default BuildStep withModifiers(@Nonnull Modifier first, @Nonnull Modifier... rest) {
+    default BuildStep withModifiers(@Nonnull FieldModifier first, @Nonnull FieldModifier... rest) {
       return withModifier(EnumSet.of(first, rest));
     }
   }
@@ -113,7 +161,7 @@ public class SootField extends SootClassMember<FieldSignature> implements Field 
   public static class SootFieldBuilder implements SignatureStep, ModifierStep, BuildStep {
 
     private FieldSignature signature;
-    private Iterable<Modifier> modifiers;
+    private Iterable<FieldModifier> modifiers;
     private Position position = NoPositionInformation.getInstance();
 
     @Nonnull
@@ -122,7 +170,7 @@ public class SootField extends SootClassMember<FieldSignature> implements Field 
     }
 
     @Nonnull
-    protected Iterable<Modifier> getModifiers() {
+    protected Iterable<FieldModifier> getModifiers() {
       return modifiers;
     }
 
@@ -140,7 +188,7 @@ public class SootField extends SootClassMember<FieldSignature> implements Field 
 
     @Override
     @Nonnull
-    public BuildStep withModifier(@Nonnull Iterable<Modifier> modifiers) {
+    public BuildStep withModifier(@Nonnull Iterable<FieldModifier> modifiers) {
       this.modifiers = modifiers;
       return this;
     }

--- a/sootup.core/src/main/java/sootup/core/model/SootMethod.java
+++ b/sootup.core/src/main/java/sootup/core/model/SootMethod.java
@@ -24,6 +24,7 @@ package sootup.core.model;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
@@ -56,6 +57,7 @@ import sootup.core.util.printer.StmtPrinter;
  */
 public class SootMethod extends SootClassMember<MethodSignature> implements Method, Copyable {
 
+  @Nonnull private final ImmutableSet<MethodModifier> modifiers;
   /**
    * An array of parameter types taken by this <code>SootMethod</code> object, in declaration order.
    */
@@ -71,13 +73,14 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
   public SootMethod(
       @Nonnull BodySource source,
       @Nonnull MethodSignature methodSignature,
-      @Nonnull Iterable<Modifier> modifiers,
+      @Nonnull Iterable<MethodModifier> modifiers,
       @Nonnull Iterable<ClassType> thrownExceptions,
       @Nonnull Position position) {
-    super(methodSignature, modifiers, position);
+    super(methodSignature, position);
 
     this.bodySource = source;
     this.parameterTypes = ImmutableUtils.immutableListOf(methodSignature.getParameterTypes());
+    this.modifiers = ImmutableUtils.immutableEnumSetOf(modifiers);
     this.exceptions = ImmutableUtils.immutableListOf(thrownExceptions);
   }
 
@@ -97,6 +100,46 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
       throw new ResolveException(
           "Could not resolve a corresponding body for " + getSignature(), Paths.get(""), e);
     }
+  }
+
+  @Override
+  public boolean isProtected() {
+    return MethodModifier.isProtected(this.getModifiers());
+  }
+
+  @Override
+  public boolean isPrivate() {
+    return MethodModifier.isPrivate(this.getModifiers());
+  }
+
+  @Override
+  public boolean isPublic() {
+    return MethodModifier.isPublic(this.getModifiers());
+  }
+
+  @Override
+  public boolean isStatic() {
+    return MethodModifier.isStatic(this.getModifiers());
+  }
+
+  @Override
+  public boolean isFinal() {
+    return MethodModifier.isFinal(this.getModifiers());
+  }
+
+  /**
+   * Gets the modifiers of this class member in an immutable set.
+   *
+   * @see MethodModifier
+   */
+  @Nonnull
+  public Set<MethodModifier> getModifiers() {
+    return modifiers;
+  }
+
+  @Override
+  public int equivHashCode() {
+    return Objects.hash(modifiers, getSignature());
   }
 
   /** Returns true if this method is not abstract or native, i.e. this method can have a body. */
@@ -151,17 +194,17 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
 
   /** Convenience method returning true if this method is abstract. */
   public boolean isAbstract() {
-    return Modifier.isAbstract(this.getModifiers());
+    return MethodModifier.isAbstract(this.getModifiers());
   }
 
   /** Convenience method returning true if this method is native. */
   public boolean isNative() {
-    return Modifier.isNative(this.getModifiers());
+    return MethodModifier.isNative(this.getModifiers());
   }
 
   /** Convenience method returning true if this method is synchronized. */
   public boolean isSynchronized() {
-    return Modifier.isSynchronized(this.getModifiers());
+    return MethodModifier.isSynchronized(this.getModifiers());
   }
 
   /** @return yes if this is the main method */
@@ -183,8 +226,8 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
   public void toString(@Nonnull StmtPrinter printer) {
 
     // print modifiers
-    final Set<Modifier> modifiers = getModifiers();
-    printer.modifier(Modifier.toString(modifiers));
+    final Set<MethodModifier> modifiers = getModifiers();
+    printer.modifier(MethodModifier.toString(modifiers));
     if (modifiers.size() != 0) {
       printer.literal(" ");
     }
@@ -228,7 +271,7 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
   }
 
   @Nonnull
-  public SootMethod withModifiers(Iterable<Modifier> modifiers) {
+  public SootMethod withModifiers(Iterable<MethodModifier> modifiers) {
     return new SootMethod(
         bodySource, getSignature(), modifiers, getExceptionSignatures(), getPosition());
   }
@@ -271,10 +314,11 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
 
   public interface ModifierStep {
     @Nonnull
-    ThrownExceptionsStep withModifier(@Nonnull Iterable<Modifier> modifier);
+    ThrownExceptionsStep withModifier(@Nonnull Iterable<MethodModifier> modifier);
 
     @Nonnull
-    default ThrownExceptionsStep withModifiers(@Nonnull Modifier first, @Nonnull Modifier... rest) {
+    default ThrownExceptionsStep withModifiers(
+        @Nonnull MethodModifier first, @Nonnull MethodModifier... rest) {
       return withModifier(EnumSet.of(first, rest));
     }
   }
@@ -304,13 +348,13 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
       implements MethodSourceStep, SignatureStep, ModifierStep, ThrownExceptionsStep, BuildStep {
 
     @Nullable private BodySource source;
-    @Nonnull private Iterable<Modifier> modifiers = Collections.emptyList();
+    @Nonnull private Iterable<MethodModifier> modifiers = Collections.emptyList();
     @Nullable private MethodSignature methodSignature;
     @Nonnull private Iterable<ClassType> thrownExceptions = Collections.emptyList();
     @Nonnull private Position position = NoPositionInformation.getInstance();
 
     @Nonnull
-    public Iterable<Modifier> getModifiers() {
+    public Iterable<MethodModifier> getModifiers() {
       return modifiers;
     }
 
@@ -350,7 +394,7 @@ public class SootMethod extends SootClassMember<MethodSignature> implements Meth
 
     @Override
     @Nonnull
-    public ThrownExceptionsStep withModifier(@Nonnull Iterable<Modifier> modifiers) {
+    public ThrownExceptionsStep withModifier(@Nonnull Iterable<MethodModifier> modifiers) {
       this.modifiers = modifiers;
       return this;
     }

--- a/sootup.core/src/main/java/sootup/core/util/printer/JimplePrinter.java
+++ b/sootup.core/src/main/java/sootup/core/util/printer/JimplePrinter.java
@@ -30,9 +30,9 @@ import sootup.core.jimple.basic.Local;
 import sootup.core.jimple.basic.Trap;
 import sootup.core.jimple.common.stmt.Stmt;
 import sootup.core.model.Body;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.Field;
 import sootup.core.model.Method;
-import sootup.core.model.Modifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootField;
 import sootup.core.model.SootMethod;
@@ -136,16 +136,16 @@ public class JimplePrinter {
             }
       */
 
-      EnumSet<Modifier> modifiers = EnumSet.copyOf(cl.getModifiers());
+      EnumSet<ClassModifier> modifiers = EnumSet.copyOf(cl.getModifiers());
       // remove unwanted modifier combinations
-      if (cl.isInterface() && Modifier.isAbstract(modifiers)) {
-        modifiers.remove(Modifier.ABSTRACT);
+      if (cl.isInterface() && ClassModifier.isAbstract(modifiers)) {
+        modifiers.remove(ClassModifier.ABSTRACT);
       }
       if (modifiers.size() != 0) {
-        printer.modifier(Modifier.toString(modifiers));
+        printer.modifier(ClassModifier.toString(modifiers));
         printer.literal(" ");
       }
-      if (!Modifier.isInterface(modifiers) && !Modifier.isAnnotation(modifiers)) {
+      if (!ClassModifier.isInterface(modifiers) && !ClassModifier.isAnnotation(modifiers)) {
         printer.literal("class ");
       }
 

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmAnnotationClassSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmAnnotationClassSource.java
@@ -77,7 +77,7 @@ public class AsmAnnotationClassSource extends JavaAnnotationSootClassSource {
               Type fieldType = AsmUtil.toJimpleType(fieldNode.desc);
               FieldSignature fieldSignature =
                   signatureFactory.getFieldSignature(fieldName, classSignature, fieldType);
-              EnumSet<Modifier> modifiers = AsmUtil.getModifiers(fieldNode.access);
+              EnumSet<FieldModifier> modifiers = AsmUtil.getFieldModifiers(fieldNode.access);
 
               // TODO: add Position info
               return new JavaSootField(
@@ -108,7 +108,7 @@ public class AsmAnnotationClassSource extends JavaAnnotationSootClassSource {
               exceptions.addAll(AsmUtil.asmIdToSignature(methodSource.exceptions));
 
               String methodName = methodSource.name;
-              EnumSet<Modifier> modifiers = AsmUtil.getModifiers(methodSource.access);
+              EnumSet<MethodModifier> modifiers = AsmUtil.getMethodModifiers(methodSource.access);
               List<Type> sigTypes = AsmUtil.toJimpleSignatureDesc(methodSource.desc);
               Type retType = sigTypes.remove(sigTypes.size() - 1);
 
@@ -173,8 +173,8 @@ public class AsmAnnotationClassSource extends JavaAnnotationSootClassSource {
   }
 
   @Nonnull
-  public EnumSet<Modifier> resolveModifiers() {
-    return AsmUtil.getModifiers(classNode.access);
+  public EnumSet<ClassModifier> resolveModifiers() {
+    return AsmUtil.getClassModifiers(classNode.access);
   }
 
   @Nonnull

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmClassSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmClassSource.java
@@ -63,7 +63,7 @@ class AsmClassSource extends JavaSootClassSource {
               Type fieldType = AsmUtil.toJimpleType(fieldNode.desc);
               FieldSignature fieldSignature =
                   signatureFactory.getFieldSignature(fieldName, classSignature, fieldType);
-              EnumSet<Modifier> modifiers = AsmUtil.getModifiers(fieldNode.access);
+              EnumSet<FieldModifier> modifiers = AsmUtil.getFieldModifiers(fieldNode.access);
 
               // TODO: add Position info
               return new JavaSootField(
@@ -120,7 +120,7 @@ class AsmClassSource extends JavaSootClassSource {
                   new ArrayList<>(AsmUtil.asmIdToSignature(methodSource.exceptions));
 
               String methodName = methodSource.name;
-              EnumSet<Modifier> modifiers = AsmUtil.getModifiers(methodSource.access);
+              EnumSet<MethodModifier> modifiers = AsmUtil.getMethodModifiers(methodSource.access);
               List<Type> sigTypes = AsmUtil.toJimpleSignatureDesc(methodSource.desc);
               Type retType = sigTypes.remove(sigTypes.size() - 1);
 
@@ -154,8 +154,8 @@ class AsmClassSource extends JavaSootClassSource {
   }
 
   @Nonnull
-  public EnumSet<Modifier> resolveModifiers() {
-    return AsmUtil.getModifiers(classNode.access);
+  public EnumSet<ClassModifier> resolveModifiers() {
+    return AsmUtil.getClassModifiers(classNode.access);
   }
 
   @Nonnull

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmMethodSource.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmMethodSource.java
@@ -182,7 +182,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
 
   @Override
   @Nonnull
-  public Body resolveBody(@Nonnull Iterable<Modifier> modifierIt) {
+  public Body resolveBody(@Nonnull Iterable<MethodModifier> modifierIt) {
 
     /* initialize */
     nextLocal = maxLocals;
@@ -205,7 +205,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
     /* build body (add stmts, locals, traps, etc.) */
     final MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
     Body.BodyBuilder bodyBuilder = Body.builder(graph);
-    bodyBuilder.setModifiers(AsmUtil.getModifiers(access));
+    bodyBuilder.setModifiers(AsmUtil.getMethodModifiers(access));
 
     final List<Stmt> preambleStmts = buildPreambleLocals(bodyBuilder);
 
@@ -1880,7 +1880,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
 
     int localIdx = 0;
     // create this Local if necessary ( i.e. not static )
-    if (!bodyBuilder.getModifiers().contains(Modifier.STATIC)) {
+    if (!bodyBuilder.getModifiers().contains(MethodModifier.STATIC)) {
       JavaLocal thisLocal = JavaJimple.newLocal(determineLocalName(localIdx), declaringClass);
       locals.set(localIdx++, thisLocal);
       final JIdentityStmt<JThisRef> stmt =

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmUtil.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/frontend/AsmUtil.java
@@ -42,7 +42,9 @@ import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceMethodVisitor;
 import sootup.core.frontend.ResolveException;
 import sootup.core.jimple.common.constant.ClassConstant;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
+import sootup.core.model.FieldModifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.types.PrimitiveType;
 import sootup.core.types.Type;
 import sootup.core.types.VoidType;
@@ -99,11 +101,35 @@ public final class AsmUtil {
     return str.replace('/', '.');
   }
 
-  public static EnumSet<Modifier> getModifiers(int access) {
-    EnumSet<Modifier> modifierEnumSet = EnumSet.noneOf(Modifier.class);
+  public static EnumSet<ClassModifier> getClassModifiers(int access) {
+    EnumSet<ClassModifier> modifierEnumSet = EnumSet.noneOf(ClassModifier.class);
 
     // add all modifiers for which (access & ABSTRACT) =! 0
-    for (Modifier modifier : Modifier.values()) {
+    for (ClassModifier modifier : ClassModifier.values()) {
+      if ((access & modifier.getBytecode()) != 0) {
+        modifierEnumSet.add(modifier);
+      }
+    }
+    return modifierEnumSet;
+  }
+
+  public static EnumSet<MethodModifier> getMethodModifiers(int access) {
+    EnumSet<MethodModifier> modifierEnumSet = EnumSet.noneOf(MethodModifier.class);
+
+    // add all modifiers for which (access & ABSTRACT) =! 0
+    for (MethodModifier modifier : MethodModifier.values()) {
+      if ((access & modifier.getBytecode()) != 0) {
+        modifierEnumSet.add(modifier);
+      }
+    }
+    return modifierEnumSet;
+  }
+
+  public static EnumSet<FieldModifier> getFieldModifiers(int access) {
+    EnumSet<FieldModifier> modifierEnumSet = EnumSet.noneOf(FieldModifier.class);
+
+    // add all modifiers for which (access & ABSTRACT) =! 0
+    for (FieldModifier modifier : FieldModifier.values()) {
       if ((access & modifier.getBytecode()) != 0) {
         modifierEnumSet.add(modifier);
       }

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/DeadAssignmentEliminator.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/DeadAssignmentEliminator.java
@@ -36,7 +36,7 @@ import sootup.core.jimple.common.ref.JInstanceFieldRef;
 import sootup.core.jimple.common.stmt.JAssignStmt;
 import sootup.core.jimple.common.stmt.Stmt;
 import sootup.core.model.Body;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.transform.BodyInterceptor;
 import sootup.core.types.*;
 import sootup.core.views.View;
@@ -73,7 +73,7 @@ public class DeadAssignmentEliminator implements BodyInterceptor {
 
     // Make a first pass through the statements, noting the statements we must absolutely keep
 
-    boolean isStatic = Modifier.isStatic(builder.getModifiers());
+    boolean isStatic = MethodModifier.isStatic(builder.getModifiers());
     boolean allEssential = true;
     boolean containsInvoke = false;
     Local thisLocal = null;

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocationTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocationTest.java
@@ -37,7 +37,6 @@ import javax.annotation.Nonnull;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.frontend.AbstractClassSource;
 import sootup.core.frontend.BodySource;
 import sootup.core.inputlocation.EagerInputLocation;
 import sootup.core.model.*;

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocationTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocationTest.java
@@ -336,9 +336,7 @@ public class PathBasedAnalysisInputLocationTest extends AnalysisInputLocationTes
     assertTrue(
         foundMethod.getParameterTypes().stream()
             .anyMatch(
-                type -> {
-                  return "int".equals(type.toString());
-                }));
+                type -> "int".equals(type.toString())));
 
     // Parse sub-signature for "empName" field
     FieldSubSignature nameFieldSubSignature =
@@ -362,7 +360,7 @@ public class PathBasedAnalysisInputLocationTest extends AnalysisInputLocationTes
                         .withSignature(
                             JavaIdentifierFactory.getInstance()
                                 .getFieldSignature(classSignature, nameFieldSubSignature))
-                        .withModifiers(Modifier.PUBLIC)
+                        .withModifiers(FieldModifier.PUBLIC)
                         .build()),
                 ImmutableUtils.immutableSet(
                     SootMethod.builder()
@@ -370,7 +368,7 @@ public class PathBasedAnalysisInputLocationTest extends AnalysisInputLocationTes
                             new BodySource() {
                               @Nonnull
                               @Override
-                              public Body resolveBody(@Nonnull Iterable<Modifier> modifiers) {
+                              public Body resolveBody(@Nonnull Iterable<MethodModifier> modifiers) {
                                 /* [ms] violating @Nonnull */
                                 return null;
                               }
@@ -392,10 +390,10 @@ public class PathBasedAnalysisInputLocationTest extends AnalysisInputLocationTes
                             JavaIdentifierFactory.getInstance()
                                 .getMethodSignature(
                                     classSignature, optionalToStreamMethodSubSignature))
-                        .withModifiers(Modifier.PUBLIC)
+                        .withModifiers(MethodModifier.PUBLIC)
                         .build()),
                 null,
-                EnumSet.of(Modifier.PUBLIC),
+                EnumSet.of(ClassModifier.PUBLIC),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList()),

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocationTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocationTest.java
@@ -334,9 +334,7 @@ public class PathBasedAnalysisInputLocationTest extends AnalysisInputLocationTes
     assertEquals("void", foundMethod.getReturnType().toString());
     assertEquals(1, foundMethod.getParameterCount());
     assertTrue(
-        foundMethod.getParameterTypes().stream()
-            .anyMatch(
-                type -> "int".equals(type.toString())));
+        foundMethod.getParameterTypes().stream().anyMatch(type -> "int".equals(type.toString())));
 
     // Parse sub-signature for "empName" field
     FieldSubSignature nameFieldSubSignature =
@@ -420,8 +418,6 @@ public class PathBasedAnalysisInputLocationTest extends AnalysisInputLocationTes
             .build()
             .createView();
 
-    final Collection<? extends AbstractClassSource> classSources =
-        pathBasedNamespace.getClassSources(v);
     // test some standard jre classes
     runtimeContains(v, "Object", "java.lang");
     runtimeContains(v, "List", "java.util");
@@ -445,7 +441,7 @@ public class PathBasedAnalysisInputLocationTest extends AnalysisInputLocationTes
                 new JavaClassPathAnalysisInputLocation(
                     System.getProperty("java.home") + "/lib/rt.jar", SourceType.Library))
             .build();
-    JavaView view = javaProject.createOnDemandView();
+    JavaView view = javaProject.createView();
 
     Collection<SootClass<JavaSootClassSource>> classes =
         new HashSet<>(); // Set to track the classes to check

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/AnnotationLibraryTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/AnnotationLibraryTest.java
@@ -7,7 +7,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.util.printer.JimplePrinter;
 import sootup.java.bytecode.minimaltestsuite.MinimalBytecodeTestSuiteBase;
@@ -24,7 +24,7 @@ public class AnnotationLibraryTest extends MinimalBytecodeTestSuiteBase {
     JimplePrinter p = new JimplePrinter(JimplePrinter.Option.LegacyMode);
     StringWriter out = new StringWriter();
     p.printTo(sootClass, new PrintWriter(out));
-    assertTrue(Modifier.isAnnotation(sootClass.getModifiers()));
+    assertTrue(ClassModifier.isAnnotation(sootClass.getModifiers()));
   }
 
   // TODO: [ms] add test for more annotation declarations e.g. inheritance

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/DeclareFieldTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/DeclareFieldTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -42,19 +42,15 @@ public class DeclareFieldTest extends MinimalBytecodeTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getModifiers().contains(Modifier.PRIVATE)
-                      && sootField.getModifiers().contains(Modifier.STATIC)
-                      && sootField.getName().equals("i");
-                }));
+                sootField -> sootField.getModifiers().contains(FieldModifier.PRIVATE)
+                    && sootField.getModifiers().contains(FieldModifier.STATIC)
+                    && sootField.getName().equals("i")));
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getModifiers().contains(Modifier.PUBLIC)
-                      && sootField.getModifiers().contains(Modifier.FINAL)
-                      && sootField.getName().equals("s");
-                }));
+                sootField -> sootField.getModifiers().contains(FieldModifier.PUBLIC)
+                    && sootField.getModifiers().contains(FieldModifier.FINAL)
+                    && sootField.getName().equals("s")));
   }
 
   /**

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/DeclareFieldTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/DeclareFieldTest.java
@@ -42,15 +42,17 @@ public class DeclareFieldTest extends MinimalBytecodeTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getModifiers().contains(FieldModifier.PRIVATE)
-                    && sootField.getModifiers().contains(FieldModifier.STATIC)
-                    && sootField.getName().equals("i")));
+                sootField ->
+                    sootField.getModifiers().contains(FieldModifier.PRIVATE)
+                        && sootField.getModifiers().contains(FieldModifier.STATIC)
+                        && sootField.getName().equals("i")));
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getModifiers().contains(FieldModifier.PUBLIC)
-                    && sootField.getModifiers().contains(FieldModifier.FINAL)
-                    && sootField.getName().equals("s")));
+                sootField ->
+                    sootField.getModifiers().contains(FieldModifier.PUBLIC)
+                        && sootField.getModifiers().contains(FieldModifier.FINAL)
+                        && sootField.getName().equals("s")));
   }
 
   /**

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/PublicClassTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/PublicClassTest.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -24,7 +24,7 @@ public class PublicClassTest extends MinimalBytecodeTestSuiteBase {
   @Test
   public void test() {
     SootClass<?> clazz = loadClass(getDeclaredClassSignature());
-    assertEquals(EnumSet.of(Modifier.PUBLIC, Modifier.SYNCHRONIZED), clazz.getModifiers());
+    assertEquals(EnumSet.of(ClassModifier.PUBLIC, ClassModifier.SUPER), clazz.getModifiers());
 
     SootMethod method;
     method = clazz.getMethod(getMethodSignature("private").getSubSignature()).get();

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/TransientVariableTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/TransientVariableTest.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -34,7 +34,7 @@ public class TransientVariableTest extends MinimalBytecodeTestSuiteBase {
             .anyMatch(
                 sootField ->
                     sootField.getName().equals("transientVar")
-                        && sootField.getModifiers().contains(Modifier.TRANSIENT)));
+                        && sootField.getModifiers().contains(FieldModifier.TRANSIENT)));
   }
 
   /**

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/VolatileVariableTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/VolatileVariableTest.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -32,10 +32,8 @@ public class VolatileVariableTest extends MinimalBytecodeTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getName().equals("counter")
-                      && sootField.getModifiers().contains(Modifier.VOLATILE);
-                }));
+                sootField -> sootField.getName().equals("counter")
+                    && sootField.getModifiers().contains(FieldModifier.VOLATILE)));
   }
 
   /**

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/VolatileVariableTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java6/VolatileVariableTest.java
@@ -32,8 +32,9 @@ public class VolatileVariableTest extends MinimalBytecodeTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getName().equals("counter")
-                    && sootField.getModifiers().contains(FieldModifier.VOLATILE)));
+                sootField ->
+                    sootField.getName().equals("counter")
+                        && sootField.getModifiers().contains(FieldModifier.VOLATILE)));
   }
 
   /**

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java8/RepeatingAnnotationsTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/minimaltestsuite/java8/RepeatingAnnotationsTest.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -32,7 +32,7 @@ public class RepeatingAnnotationsTest extends MinimalBytecodeTestSuiteBase {
     SootMethod method = loadMethod(getMethodSignature());
     assertJimpleStmts(method, expectedBodyStmts());
     SootClass sootClass = loadClass(getDeclaredClassSignature());
-    assertTrue(Modifier.isAnnotation(sootClass.getModifiers()));
+    assertTrue(ClassModifier.isAnnotation(sootClass.getModifiers()));
   }
 
   @Override

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaAnnotationSootMethod.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaAnnotationSootMethod.java
@@ -3,7 +3,7 @@ package sootup.java.core;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import sootup.core.frontend.BodySource;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.model.Position;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
@@ -13,7 +13,7 @@ public class JavaAnnotationSootMethod extends JavaSootMethod {
   public JavaAnnotationSootMethod(
       @Nonnull BodySource source,
       @Nonnull MethodSignature methodSignature,
-      @Nonnull Iterable<Modifier> modifiers,
+      @Nonnull Iterable<MethodModifier> modifiers,
       @Nonnull Iterable<ClassType> thrownExceptions,
       @Nonnull Iterable<AnnotationUsage> annotations,
       @Nonnull Position position) {

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaSootClass.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaSootClass.java
@@ -184,7 +184,7 @@ public class JavaSootClass extends SootClass<JavaSootClassSource> {
   }
 
   @Nonnull
-  public JavaSootClass withModifiers(@Nonnull Set<Modifier> modifiers) {
+  public JavaSootClass withModifiers(@Nonnull Set<ClassModifier> modifiers) {
     return new JavaSootClass(
         new OverridingJavaClassSource(getClassSource()).withModifiers(modifiers), sourceType);
   }

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaSootField.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaSootField.java
@@ -25,7 +25,7 @@ package sootup.java.core;
 import java.util.Collections;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.Position;
 import sootup.core.model.SootField;
 import sootup.core.signatures.FieldSignature;
@@ -38,14 +38,14 @@ public class JavaSootField extends SootField {
   /**
    * Constructs a Soot field with the given name, type and modifiers.
    *
-   * @param signature
-   * @param modifiers
-   * @param annotations
-   * @param position
+   * @param signature the signature of the field
+   * @param modifiers modifier of the field
+   * @param annotations annotations of the field
+   * @param position position of the field
    */
   public JavaSootField(
       @Nonnull FieldSignature signature,
-      @Nonnull Iterable<Modifier> modifiers,
+      @Nonnull Iterable<FieldModifier> modifiers,
       @Nonnull Iterable<AnnotationUsage> annotations,
       Position position) {
     super(signature, modifiers, position);

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaSootMethod.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaSootMethod.java
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 import sootup.core.frontend.BodySource;
 import sootup.core.frontend.OverridingBodySource;
 import sootup.core.model.Body;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.model.Position;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -45,7 +45,7 @@ public class JavaSootMethod extends SootMethod {
   public JavaSootMethod(
       @Nonnull BodySource source,
       @Nonnull MethodSignature methodSignature,
-      @Nonnull Iterable<Modifier> modifiers,
+      @Nonnull Iterable<MethodModifier> modifiers,
       @Nonnull Iterable<ClassType> thrownExceptions,
       @Nonnull Iterable<AnnotationUsage> annotations,
       @Nonnull Position position) {
@@ -116,7 +116,7 @@ public class JavaSootMethod extends SootMethod {
 
   @Nonnull
   @Override
-  public JavaSootMethod withModifiers(@Nonnull Iterable<Modifier> modifiers) {
+  public JavaSootMethod withModifiers(@Nonnull Iterable<MethodModifier> modifiers) {
     return new JavaSootMethod(
         bodySource,
         getSignature(),

--- a/sootup.java.core/src/main/java/sootup/java/core/OverridingJavaClassSource.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/OverridingJavaClassSource.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import sootup.core.frontend.ResolveException;
 import sootup.core.frontend.SootClassSource;
 import sootup.core.inputlocation.AnalysisInputLocation;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.Position;
 import sootup.core.model.SootField;
 import sootup.core.model.SootMethod;
@@ -55,7 +55,7 @@ public class OverridingJavaClassSource extends JavaSootClassSource {
 
   @Nullable private final Collection<SootMethod> overriddenSootMethods;
   @Nullable private final Collection<SootField> overriddenSootFields;
-  @Nullable private final Set<Modifier> overriddenModifiers;
+  @Nullable private final Set<ClassModifier> overriddenModifiers;
   @Nullable private final Set<ClassType> overriddenInterfaces;
   @Nullable private final Optional<ClassType> overriddenSuperclass;
   @Nullable private final Optional<ClassType> overriddenOuterClass;
@@ -84,7 +84,7 @@ public class OverridingJavaClassSource extends JavaSootClassSource {
   private OverridingJavaClassSource(
       @Nullable Collection<SootMethod> overriddenSootMethods,
       @Nullable Collection<SootField> overriddenSootFields,
-      @Nullable Set<Modifier> overriddenModifiers,
+      @Nullable Set<ClassModifier> overriddenModifiers,
       @Nullable Set<ClassType> overriddenInterfaces,
       @Nullable Optional<ClassType> overriddenSuperclass,
       @Nullable Optional<ClassType> overriddenOuterClass,
@@ -118,7 +118,7 @@ public class OverridingJavaClassSource extends JavaSootClassSource {
       @Nonnull Set<SootField> sootFields,
       @Nonnull Set<SootMethod> sootMethods,
       @Nonnull Position position,
-      @Nonnull EnumSet<Modifier> modifiers,
+      @Nonnull EnumSet<ClassModifier> modifiers,
       @Nonnull Iterable<AnnotationUsage> annotations,
       @Nonnull Iterable<AnnotationUsage> methodAnnotations,
       @Nullable Iterable<AnnotationUsage> fieldAnnotations) {
@@ -151,7 +151,7 @@ public class OverridingJavaClassSource extends JavaSootClassSource {
 
   @Nonnull
   @Override
-  public Set<Modifier> resolveModifiers() {
+  public Set<ClassModifier> resolveModifiers() {
     return overriddenModifiers != null ? overriddenModifiers : delegate.resolveModifiers();
   }
 
@@ -293,7 +293,7 @@ public class OverridingJavaClassSource extends JavaSootClassSource {
   }
 
   @Nonnull
-  public OverridingJavaClassSource withModifiers(@Nonnull Set<Modifier> overriddenModifiers) {
+  public OverridingJavaClassSource withModifiers(@Nonnull Set<ClassModifier> overriddenModifiers) {
     return new OverridingJavaClassSource(
         overriddenSootMethods,
         overriddenSootFields,

--- a/sootup.java.core/src/test/java/sootup/java/core/jimple/common/ref/JFieldRefTest.java
+++ b/sootup.java.core/src/test/java/sootup/java/core/jimple/common/ref/JFieldRefTest.java
@@ -17,7 +17,8 @@ import sootup.core.jimple.basic.Local;
 import sootup.core.jimple.basic.NoPositionInformation;
 import sootup.core.jimple.common.ref.JInstanceFieldRef;
 import sootup.core.jimple.common.ref.JStaticFieldRef;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootField;
 import sootup.core.model.SourceType;
 import sootup.core.signatures.FieldSignature;
@@ -49,7 +50,8 @@ public class JFieldRefTest {
         JavaIdentifierFactory.getInstance().getClassType("dummyMainClass");
     FieldSignature fieldSig = fact.getFieldSignature("dummyField", declaringClassSignature, "int");
     SootField field =
-        new SootField(fieldSig, EnumSet.of(Modifier.FINAL), NoPositionInformation.getInstance());
+        new SootField(
+            fieldSig, EnumSet.of(FieldModifier.FINAL), NoPositionInformation.getInstance());
 
     JavaSootClass mainClass =
         new JavaSootClass(
@@ -63,7 +65,7 @@ public class JFieldRefTest {
                 Collections.singleton(field),
                 Collections.emptySet(),
                 null,
-                EnumSet.of(Modifier.PUBLIC),
+                EnumSet.of(ClassModifier.PUBLIC),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList()),
@@ -75,7 +77,7 @@ public class JFieldRefTest {
     final Optional<? extends SootField> field1 = view.getField(ref.getFieldSignature());
     assertTrue(field1.isPresent());
     assertEquals(field, field1.get());
-    assertEquals(EnumSet.of(Modifier.FINAL), field1.get().getModifiers());
+    assertEquals(EnumSet.of(FieldModifier.FINAL), field1.get().getModifiers());
   }
 
   @Ignore
@@ -85,7 +87,8 @@ public class JFieldRefTest {
         JavaIdentifierFactory.getInstance().getClassType("dummyMainClass");
     FieldSignature fieldSig = fact.getFieldSignature("dummyField", declaringClassSignature, "int");
     SootField field =
-        new SootField(fieldSig, EnumSet.of(Modifier.FINAL), NoPositionInformation.getInstance());
+        new SootField(
+            fieldSig, EnumSet.of(FieldModifier.FINAL), NoPositionInformation.getInstance());
 
     JavaSootClass mainClass =
         new JavaSootClass(
@@ -99,7 +102,7 @@ public class JFieldRefTest {
                 Collections.singleton(field),
                 Collections.emptySet(),
                 null,
-                EnumSet.of(Modifier.PUBLIC),
+                EnumSet.of(ClassModifier.PUBLIC),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList()),
@@ -112,6 +115,6 @@ public class JFieldRefTest {
     final Optional<? extends SootField> field1 = view.getField(ref.getFieldSignature());
     assertTrue(field1.isPresent());
     assertEquals(fieldSig, field1.get().getSignature());
-    assertEquals(EnumSet.of(Modifier.FINAL), field1.get().getModifiers());
+    assertEquals(EnumSet.of(FieldModifier.FINAL), field1.get().getModifiers());
   }
 }

--- a/sootup.java.core/src/test/java/sootup/java/core/jimple/common/stmt/JInvokeStmtTest.java
+++ b/sootup.java.core/src/test/java/sootup/java/core/jimple/common/stmt/JInvokeStmtTest.java
@@ -47,7 +47,7 @@ import sootup.core.jimple.common.expr.JStaticInvokeExpr;
 import sootup.core.jimple.common.stmt.JInvokeStmt;
 import sootup.core.jimple.common.stmt.JNopStmt;
 import sootup.core.jimple.common.stmt.Stmt;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootField;
 import sootup.core.model.SootMethod;
@@ -83,7 +83,7 @@ public class JInvokeStmtTest {
             fields,
             methods,
             NoPositionInformation.getInstance(),
-            EnumSet.of(Modifier.PUBLIC),
+            EnumSet.of(ClassModifier.PUBLIC),
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList());

--- a/sootup.java.core/src/test/java/sootup/java/core/model/SootMethodTest.java
+++ b/sootup.java.core/src/test/java/sootup/java/core/model/SootMethodTest.java
@@ -19,7 +19,8 @@ import sootup.core.jimple.basic.StmtPositionInfo;
 import sootup.core.jimple.common.stmt.JIdentityStmt;
 import sootup.core.jimple.common.stmt.JReturnVoidStmt;
 import sootup.core.model.Body;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.model.SourceType;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
@@ -73,7 +74,7 @@ public class SootMethodTest {
         new JavaSootMethod(
             new OverridingBodySource(methodSignature, body),
             methodSignature,
-            EnumSet.of(Modifier.PUBLIC, Modifier.STATIC),
+            EnumSet.of(MethodModifier.PUBLIC, MethodModifier.STATIC),
             Collections.emptyList(),
             Collections.emptyList(),
             NoPositionInformation.getInstance());
@@ -90,7 +91,7 @@ public class SootMethodTest {
                 Collections.emptySet(),
                 Collections.singleton(dummyMainMethod),
                 NoPositionInformation.getInstance(),
-                EnumSet.of(Modifier.PUBLIC),
+                EnumSet.of(ClassModifier.PUBLIC),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList()),

--- a/sootup.java.core/src/test/java/sootup/java/core/printer/JimplePrinterTest.java
+++ b/sootup.java.core/src/test/java/sootup/java/core/printer/JimplePrinterTest.java
@@ -81,7 +81,7 @@ public class JimplePrinterTest {
         new SootMethod(
             new OverridingBodySource(methodSignatureOne, bodyOne),
             methodSignatureOne,
-            EnumSet.of(Modifier.PUBLIC, Modifier.STATIC),
+            EnumSet.of(MethodModifier.PUBLIC, MethodModifier.STATIC),
             Collections.emptyList(),
             NoPositionInformation.getInstance());
 
@@ -97,7 +97,7 @@ public class JimplePrinterTest {
         new SootMethod(
             new OverridingBodySource(methodSignatureOne, bodyTwo),
             methodSignatureTwo,
-            EnumSet.of(Modifier.PRIVATE),
+            EnumSet.of(MethodModifier.PRIVATE),
             Collections.singletonList(
                 JavaIdentifierFactory.getInstance()
                     .getClassType("files.stuff.FileNotFoundException")),
@@ -113,9 +113,9 @@ public class JimplePrinterTest {
                             "counter",
                             JavaIdentifierFactory.getInstance().getClassType(className),
                             PrimitiveType.getInt()),
-                    EnumSet.of(Modifier.PRIVATE),
+                    EnumSet.of(FieldModifier.PRIVATE),
                     NoPositionInformation.getInstance())),
-            EnumSet.of(Modifier.PUBLIC),
+            EnumSet.of(ClassModifier.PUBLIC),
             Collections.singleton(
                 JavaIdentifierFactory.getInstance().getClassType("some.great.Interface")),
             JavaIdentifierFactory.getInstance().getClassType("some.great.Superclass"),

--- a/sootup.java.core/src/test/java/sootup/java/core/printer/LegacyJimplePrinterTest.java
+++ b/sootup.java.core/src/test/java/sootup/java/core/printer/LegacyJimplePrinterTest.java
@@ -49,7 +49,7 @@ public class LegacyJimplePrinterTest {
         new SootMethod(
             new OverridingBodySource(methodSignature, body),
             methodSignature,
-            EnumSet.of(Modifier.PUBLIC, Modifier.STATIC),
+            EnumSet.of(MethodModifier.PUBLIC, MethodModifier.STATIC),
             Collections.emptyList(),
             NoPositionInformation.getInstance());
 
@@ -57,7 +57,7 @@ public class LegacyJimplePrinterTest {
         new OverridingClassSource(
             Collections.singleton(dummyMainMethod),
             Collections.emptySet(),
-            EnumSet.of(Modifier.PUBLIC),
+            EnumSet.of(ClassModifier.PUBLIC),
             Collections.emptySet(),
             null,
             null,

--- a/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/InstructionConverter.java
+++ b/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/InstructionConverter.java
@@ -76,7 +76,7 @@ import sootup.core.jimple.common.ref.JInstanceFieldRef;
 import sootup.core.jimple.common.ref.JStaticFieldRef;
 import sootup.core.jimple.common.stmt.*;
 import sootup.core.jimple.javabytecode.stmt.JSwitchStmt;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootField;
 import sootup.core.signatures.FieldSignature;
 import sootup.core.signatures.MethodSignature;
@@ -317,7 +317,7 @@ public class InstructionConverter {
     SootField assertionsDisabled =
         new SootField(
             fieldSig,
-            EnumSet.of(Modifier.FINAL, Modifier.STATIC),
+            EnumSet.of(FieldModifier.FINAL, FieldModifier.STATIC),
             NoPositionInformation.getInstance());
 
     converter.addSootField(assertionsDisabled);
@@ -422,7 +422,7 @@ public class InstructionConverter {
                 "val$" + access.variableName, cSig, type.toString());
         SootField field =
             new SootField(
-                fieldSig, EnumSet.of(Modifier.FINAL), NoPositionInformation.getInstance());
+                fieldSig, EnumSet.of(FieldModifier.FINAL), NoPositionInformation.getInstance());
         left = Jimple.newInstanceFieldRef(localGenerator.getThisLocal(), fieldSig);
         converter.addSootField(field); // add this field to class
         // TODO in old jimple this is not supported
@@ -455,7 +455,7 @@ public class InstructionConverter {
                 "val$" + access.variableName, cSig, type.toString());
         SootField field =
             new SootField(
-                fieldSig, EnumSet.of(Modifier.FINAL), NoPositionInformation.getInstance());
+                fieldSig, EnumSet.of(FieldModifier.FINAL), NoPositionInformation.getInstance());
         rvalue = Jimple.newInstanceFieldRef(localGenerator.getThisLocal(), fieldSig);
         converter.addSootField(field); // add this field to class
       } else {

--- a/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/WalaIRToJimpleConverter.java
+++ b/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/WalaIRToJimpleConverter.java
@@ -143,7 +143,7 @@ public class WalaIRToJimpleConverter {
     Position position = walaClass.getSourcePosition();
 
     // convert modifiers
-    EnumSet<Modifier> modifiers = convertModifiers(walaClass);
+    EnumSet<ClassModifier> modifiers = convertModifiers(walaClass);
 
     // convert fields
     Set<IField> fields = HashSetFactory.make(walaClass.getDeclaredInstanceFields());
@@ -159,7 +159,8 @@ public class WalaIRToJimpleConverter {
       FieldSignature signature =
           identifierFactory.getFieldSignature("this$0", classSig, outerClass);
       SootField enclosingObject =
-          new SootField(signature, EnumSet.of(Modifier.FINAL), NoPositionInformation.getInstance());
+          new SootField(
+              signature, EnumSet.of(FieldModifier.FINAL), NoPositionInformation.getInstance());
       sootFields.add(enclosingObject);
     }
 
@@ -193,7 +194,7 @@ public class WalaIRToJimpleConverter {
       Set<SootField> sootFields,
       Set<SootMethod> sootMethods,
       Position position,
-      EnumSet<Modifier> modifiers,
+      EnumSet<ClassModifier> modifiers,
       Iterable<AnnotationType> annotations) {
     String fullyQualifiedClassName = convertClassNameFromWala(walaClass.getName().toString());
     JavaClassType classSignature = identifierFactory.getClassType(fullyQualifiedClassName);
@@ -224,7 +225,7 @@ public class WalaIRToJimpleConverter {
    */
   public SootField convertField(JavaClassType classSig, AstField walaField) {
     Type type = convertType(walaField.getFieldTypeReference());
-    EnumSet<Modifier> modifiers = convertModifiers(walaField);
+    EnumSet<FieldModifier> modifiers = convertModifiers(walaField);
     FieldSignature signature =
         identifierFactory.getFieldSignature(walaField.getName().toString(), classSig, type);
     return new SootField(signature, modifiers, NoPositionInformation.getInstance());
@@ -252,7 +253,7 @@ public class WalaIRToJimpleConverter {
 
     Type returnType = convertType(walaMethod.getReturnType());
 
-    EnumSet<Modifier> modifiers = convertModifiers(walaMethod);
+    EnumSet<MethodModifier> modifiers = convertModifiers(walaMethod);
 
     List<ClassType> thrownExceptions = new ArrayList<>();
     try {
@@ -319,96 +320,96 @@ public class WalaIRToJimpleConverter {
   }
 
   /** Return all modifiers for the given field. */
-  public EnumSet<Modifier> convertModifiers(AstField field) {
-    EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+  public EnumSet<FieldModifier> convertModifiers(AstField field) {
+    EnumSet<FieldModifier> modifiers = EnumSet.noneOf(FieldModifier.class);
     if (field.isFinal()) {
-      modifiers.add(Modifier.FINAL);
+      modifiers.add(FieldModifier.FINAL);
     }
     if (field.isPrivate()) {
-      modifiers.add(Modifier.PRIVATE);
+      modifiers.add(FieldModifier.PRIVATE);
     }
     if (field.isProtected()) {
-      modifiers.add(Modifier.PROTECTED);
+      modifiers.add(FieldModifier.PROTECTED);
     }
     if (field.isPublic()) {
-      modifiers.add(Modifier.PUBLIC);
+      modifiers.add(FieldModifier.PUBLIC);
     }
     if (field.isStatic()) {
-      modifiers.add(Modifier.STATIC);
+      modifiers.add(FieldModifier.STATIC);
     }
     if (field.isVolatile()) {
-      modifiers.add(Modifier.VOLATILE);
+      modifiers.add(FieldModifier.VOLATILE);
     }
     // TODO: TRANSIENT field
     return modifiers;
   }
 
   /** Return all modifiers for the given method. */
-  public EnumSet<Modifier> convertModifiers(AstMethod method) {
-    EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+  public EnumSet<MethodModifier> convertModifiers(AstMethod method) {
+    EnumSet<MethodModifier> modifiers = EnumSet.noneOf(MethodModifier.class);
     if (method.isPrivate()) {
-      modifiers.add(Modifier.PRIVATE);
+      modifiers.add(MethodModifier.PRIVATE);
     }
     if (method.isProtected()) {
-      modifiers.add(Modifier.PROTECTED);
+      modifiers.add(MethodModifier.PROTECTED);
     }
     if (method.isPublic()) {
-      modifiers.add(Modifier.PUBLIC);
+      modifiers.add(MethodModifier.PUBLIC);
     }
     if (method.isStatic()) {
-      modifiers.add(Modifier.STATIC);
+      modifiers.add(MethodModifier.STATIC);
     }
     if (method.isFinal()) {
-      modifiers.add(Modifier.FINAL);
+      modifiers.add(MethodModifier.FINAL);
     }
     if (method.isAbstract()) {
-      modifiers.add(Modifier.ABSTRACT);
+      modifiers.add(MethodModifier.ABSTRACT);
     }
     if (method.isSynchronized()) {
-      modifiers.add(Modifier.SYNCHRONIZED);
+      modifiers.add(MethodModifier.SYNCHRONIZED);
     }
     if (method.isNative()) {
-      modifiers.add(Modifier.NATIVE);
+      modifiers.add(MethodModifier.NATIVE);
     }
     if (method.isSynthetic()) {
-      modifiers.add(Modifier.SYNTHETIC);
+      modifiers.add(MethodModifier.SYNTHETIC);
     }
     if (method.isBridge()) {
-      modifiers.add(Modifier.VOLATILE);
+      modifiers.add(MethodModifier.BRIDGE);
     }
-    // TODO: strictfp and annotation
+    // TODO: strictfp and annotation and varargs
     return modifiers;
   }
 
-  public EnumSet<Modifier> convertModifiers(AstClass klass) {
+  public EnumSet<ClassModifier> convertModifiers(AstClass klass) {
     int modif = klass.getModifiers();
-    EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+    EnumSet<ClassModifier> modifiers = EnumSet.noneOf(ClassModifier.class);
     if (klass.isAbstract()) {
-      modifiers.add(Modifier.ABSTRACT);
+      modifiers.add(ClassModifier.ABSTRACT);
     }
     if (klass.isPrivate()) {
-      modifiers.add(Modifier.PRIVATE);
+      modifiers.add(ClassModifier.PRIVATE);
     }
     if (klass.isSynthetic()) {
-      modifiers.add(Modifier.SYNTHETIC);
+      modifiers.add(ClassModifier.SYNTHETIC);
     }
     if (klass.isPublic()) {
-      modifiers.add(Modifier.PUBLIC);
+      modifiers.add(ClassModifier.PUBLIC);
     }
     if (klass.isInterface()) {
-      modifiers.add(Modifier.INTERFACE);
+      modifiers.add(ClassModifier.INTERFACE);
     }
     if (klass.getSuperclass().getName().toString().equals("Ljava/lang/Enum")) {
-      modifiers.add(Modifier.ENUM);
+      modifiers.add(ClassModifier.ENUM);
     }
-    if ((modif & ClassConstants.ACC_FINAL) != 0) modifiers.add(Modifier.FINAL);
+    if ((modif & ClassConstants.ACC_FINAL) != 0) modifiers.add(ClassModifier.FINAL);
     // TODO:  annotation
     return modifiers;
   }
 
   @Nonnull
   private Body createBody(
-      MethodSignature methodSignature, EnumSet<Modifier> modifiers, AstMethod walaMethod) {
+      MethodSignature methodSignature, EnumSet<MethodModifier> modifiers, AstMethod walaMethod) {
 
     if (walaMethod.isAbstract()) {
       return Body.builder().setMethodSignature(methodSignature).build();
@@ -430,7 +431,7 @@ public class WalaIRToJimpleConverter {
 
         /* Look AsmMethodSourceContent.getBody, see AsmMethodSourceContent.emitLocals(); */
 
-        if (!Modifier.isStatic(modifiers)) {
+        if (!MethodModifier.isStatic(modifiers)) {
           JavaClassType thisType = (JavaClassType) methodSignature.getDeclClassType();
           Local thisLocal = localGenerator.generateThisLocal(thisType);
           Stmt stmt =

--- a/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/WalaSootMethod.java
+++ b/sootup.java.sourcecode/src/main/java/sootup/java/sourcecode/frontend/WalaSootMethod.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 import sootup.core.frontend.BodySource;
 import sootup.core.frontend.OverridingBodySource;
 import sootup.core.jimple.basic.NoPositionInformation;
-import sootup.core.model.Modifier;
+import sootup.core.model.MethodModifier;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
@@ -51,7 +51,7 @@ public class WalaSootMethod extends JavaSootMethod {
   public WalaSootMethod(
       @Nonnull BodySource source,
       @Nonnull MethodSignature methodSignature,
-      @Nonnull Iterable<Modifier> modifiers,
+      @Nonnull Iterable<MethodModifier> modifiers,
       @Nonnull Iterable<ClassType> thrownExceptions,
       DebuggingInformation debugInfo) {
 
@@ -92,7 +92,7 @@ public class WalaSootMethod extends JavaSootMethod {
   }
 
   @Nonnull
-  public JavaSootMethod withModifiers(Iterable<Modifier> modifiers) {
+  public JavaSootMethod withModifiers(Iterable<MethodModifier> modifiers) {
     return new WalaSootMethod(bodySource, getSignature(), getModifiers(), exceptions, debugInfo);
   }
 

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/AnnotationLibraryTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/AnnotationLibraryTest.java
@@ -3,7 +3,7 @@ package sootup.java.sourcecode.minimaltestsuite.java6;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Ignore;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.java.sourcecode.minimaltestsuite.MinimalSourceTestSuiteBase;
 
@@ -14,6 +14,6 @@ public class AnnotationLibraryTest extends MinimalSourceTestSuiteBase {
     // TODO: [ms] annotations are not implemented yet
     System.out.println(getDeclaredClassSignature());
     SootClass sootClass = loadClass(getDeclaredClassSignature());
-    assertTrue(Modifier.isAnnotation(sootClass.getModifiers()));
+    assertTrue(ClassModifier.isAnnotation(sootClass.getModifiers()));
   }
 }

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/DeclareFieldTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/DeclareFieldTest.java
@@ -39,15 +39,17 @@ public class DeclareFieldTest extends MinimalSourceTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getModifiers().contains(FieldModifier.PRIVATE)
-                    && sootField.getModifiers().contains(FieldModifier.STATIC)
-                    && sootField.getName().equals("i")));
+                sootField ->
+                    sootField.getModifiers().contains(FieldModifier.PRIVATE)
+                        && sootField.getModifiers().contains(FieldModifier.STATIC)
+                        && sootField.getName().equals("i")));
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getModifiers().contains(FieldModifier.PUBLIC)
-                    && sootField.getModifiers().contains(FieldModifier.FINAL)
-                    && sootField.getName().equals("s")));
+                sootField ->
+                    sootField.getModifiers().contains(FieldModifier.PUBLIC)
+                        && sootField.getModifiers().contains(FieldModifier.FINAL)
+                        && sootField.getName().equals("s")));
   }
 
   /**

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/DeclareFieldTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/DeclareFieldTest.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -39,19 +39,15 @@ public class DeclareFieldTest extends MinimalSourceTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getModifiers().contains(Modifier.PRIVATE)
-                      && sootField.getModifiers().contains(Modifier.STATIC)
-                      && sootField.getName().equals("i");
-                }));
+                sootField -> sootField.getModifiers().contains(FieldModifier.PRIVATE)
+                    && sootField.getModifiers().contains(FieldModifier.STATIC)
+                    && sootField.getName().equals("i")));
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getModifiers().contains(Modifier.PUBLIC)
-                      && sootField.getModifiers().contains(Modifier.FINAL)
-                      && sootField.getName().equals("s");
-                }));
+                sootField -> sootField.getModifiers().contains(FieldModifier.PUBLIC)
+                    && sootField.getModifiers().contains(FieldModifier.FINAL)
+                    && sootField.getName().equals("s")));
   }
 
   /**

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/NoModifierClassTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/NoModifierClassTest.java
@@ -8,7 +8,7 @@ import categories.Java8Test;
 import java.util.*;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.signatures.MethodSignature;
 import sootup.java.core.JavaSootClass;
 import sootup.java.sourcecode.minimaltestsuite.MinimalSourceTestSuiteBase;
@@ -20,7 +20,7 @@ public class NoModifierClassTest extends MinimalSourceTestSuiteBase {
   @Test
   public void test() {
     JavaSootClass clazz = loadClass(getDeclaredClassSignature());
-    assertEquals(EnumSet.noneOf(Modifier.class), clazz.getModifiers());
+    assertEquals(EnumSet.noneOf(ClassModifier.class), clazz.getModifiers());
 
     assertTrue(clazz.getMethod(getMethodSignature("private").getSubSignature()).get().isPrivate());
     assertTrue(

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/PublicClassTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/PublicClassTest.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -22,7 +22,7 @@ public class PublicClassTest extends MinimalSourceTestSuiteBase {
   @Test
   public void test() {
     SootClass<?> clazz = loadClass(getDeclaredClassSignature());
-    assertEquals(EnumSet.of(Modifier.PUBLIC), clazz.getModifiers());
+    assertEquals(EnumSet.of(ClassModifier.PUBLIC), clazz.getModifiers());
 
     SootMethod method;
     method = clazz.getMethod(getMethodSignature("private").getSubSignature()).get();

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/TransientVariableTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/TransientVariableTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Ignore;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.signatures.MethodSignature;
 import sootup.java.sourcecode.minimaltestsuite.MinimalSourceTestSuiteBase;
@@ -28,7 +28,7 @@ public class TransientVariableTest extends MinimalSourceTestSuiteBase {
             .anyMatch(
                 sootField ->
                     sootField.getName().equals("transientVar")
-                        && sootField.getModifiers().contains(Modifier.TRANSIENT)));
+                        && sootField.getModifiers().contains(FieldModifier.TRANSIENT)));
   }
 
   /**

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/VolatileVariableTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java6/VolatileVariableTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -31,7 +31,7 @@ public class VolatileVariableTest extends MinimalSourceTestSuiteBase {
             .anyMatch(
                 sootField -> {
                   return sootField.getName().equals("counter")
-                      && sootField.getModifiers().contains(Modifier.VOLATILE);
+                      && sootField.getModifiers().contains(FieldModifier.VOLATILE);
                 }));
   }
 

--- a/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java8/RepeatingAnnotationsTest.java
+++ b/sootup.java.sourcecode/src/test/java/sootup/java/sourcecode/minimaltestsuite/java8/RepeatingAnnotationsTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Ignore;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -29,7 +29,7 @@ public class RepeatingAnnotationsTest extends MinimalSourceTestSuiteBase {
     assertJimpleStmts(method, expectedBodyStmts());
 
     SootClass sootClass = loadClass(getDeclaredClassSignature());
-    assertTrue(Modifier.isAnnotation(sootClass.getModifiers()));
+    assertTrue(ClassModifier.isAnnotation(sootClass.getModifiers()));
   }
 
   @Override

--- a/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
+++ b/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
@@ -128,14 +128,17 @@ grammar Jimple;
   importItem:
     'import' location=identifier SEMICOLON;
 
+  common_modifier :
+    'final' | 'public' | 'protected' | 'private' | 'static' | 'enum'| 'synthetic';
+
   class_modifier :
-    'abstract' | 'final' | 'public' | 'protected' | 'private' | 'static' | 'super' | 'enum' | 'synthetic';
+   common_modifier | 'abstract' | 'super';
 
   method_modifier :
-    'abstract' | 'final' | 'native' | 'public' | 'protected' | 'private' | 'static' | 'synchronized' | 'varargs'| 'bridge' | 'strictfp' | 'enum'| 'synthetic';
+   common_modifier | 'abstract' | 'native' | 'synchronized' | 'varargs'| 'bridge' | 'strictfp';
 
   field_modifier :
-    'final' | 'public' | 'protected' | 'private' | 'static' | 'transient' | 'volatile' | 'enum'| 'synthetic';
+   common_modifier  | 'transient' | 'volatile';
 
   file_type :
     CLASS | 'interface' | 'annotation interface';

--- a/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
+++ b/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
@@ -123,13 +123,19 @@ grammar Jimple;
     (PLUS|MINUS)? (DEC_CONSTANT | HEX_CONSTANT ) 'L'?;
 
   file:
-    importItem* modifier* file_type classname=IDENTIFIER extends_clause? implements_clause? L_BRACE member* R_BRACE EOF;
+    importItem* class_modifier* file_type classname=IDENTIFIER extends_clause? implements_clause? L_BRACE member* R_BRACE EOF;
 
   importItem:
     'import' location=identifier SEMICOLON;
 
-  modifier :
-    'abstract' | 'final' | 'native' | 'public' | 'protected' | 'private' | 'static' | 'synchronized' | 'transient' |'volatile' | 'strictfp' | 'enum';
+  class_modifier :
+    'abstract' | 'final' | 'public' | 'protected' | 'private' | 'static' | 'super' | 'enum' | 'synthetic';
+
+  method_modifier :
+    'abstract' | 'final' | 'native' | 'public' | 'protected' | 'private' | 'static' | 'synchronized' | 'varargs'| 'bridge' | 'strictfp' | 'enum'| 'synthetic';
+
+  field_modifier :
+    'final' | 'public' | 'protected' | 'private' | 'static' | 'transient' | 'volatile' | 'enum'| 'synthetic';
 
   file_type :
     CLASS | 'interface' | 'annotation interface';
@@ -151,10 +157,10 @@ grammar Jimple;
    field | method;
 
   field :
-    modifier* type identifier SEMICOLON;
+    field_modifier* type identifier SEMICOLON;
 
   method :
-    modifier* method_subsignature throws_clause? method_body;
+    method_modifier* method_subsignature throws_clause? method_body;
 
   method_name :
     '<init>' | '<clinit>' | identifier;

--- a/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleConverter.java
+++ b/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleConverter.java
@@ -197,38 +197,22 @@ public class JimpleConverter {
     }
 
     private EnumSet<ClassModifier> getClassModifiers(List<JimpleParser.ModifierContext> modifier) {
-      Set<ClassModifier> modifierSet =
-          modifier.stream()
-              .map(
-                  modifierContext -> ClassModifier.valueOf(modifierContext.getText().toUpperCase()))
-              .collect(Collectors.toSet());
-      return modifierSet.isEmpty()
-          ? EnumSet.noneOf(ClassModifier.class)
-          : EnumSet.copyOf(modifierSet);
+      return modifier.stream()
+          .map(modContext -> ClassModifier.valueOf(modContext.getText().toUpperCase()))
+          .collect(Collectors.toCollection(() -> EnumSet.noneOf(ClassModifier.class)));
     }
 
     private EnumSet<MethodModifier> getMethodModifiers(
         List<JimpleParser.ModifierContext> modifier) {
-      Set<MethodModifier> modifierSet =
-          modifier.stream()
-              .map(
-                  modifierContext ->
-                      MethodModifier.valueOf(modifierContext.getText().toUpperCase()))
-              .collect(Collectors.toSet());
-      return modifierSet.isEmpty()
-          ? EnumSet.noneOf(MethodModifier.class)
-          : EnumSet.copyOf(modifierSet);
+      return modifier.stream()
+          .map(modContext -> MethodModifier.valueOf(modContext.getText().toUpperCase()))
+          .collect(Collectors.toCollection(() -> EnumSet.noneOf(MethodModifier.class)));
     }
 
     private EnumSet<FieldModifier> getFieldModifiers(List<JimpleParser.ModifierContext> modifier) {
-      Set<FieldModifier> modifierSet =
-          modifier.stream()
-              .map(
-                  modifierContext -> FieldModifier.valueOf(modifierContext.getText().toUpperCase()))
-              .collect(Collectors.toSet());
-      return modifierSet.isEmpty()
-          ? EnumSet.noneOf(FieldModifier.class)
-          : EnumSet.copyOf(modifierSet);
+      return modifier.stream()
+          .map(modContext -> FieldModifier.valueOf(modContext.getText().toUpperCase()))
+          .collect(Collectors.toCollection(() -> EnumSet.noneOf(FieldModifier.class)));
     }
 
     private class MethodVisitor extends JimpleBaseVisitor<SootMethod> {
@@ -354,8 +338,6 @@ public class JimpleConverter {
                       labeledStmts.get(handlerLabel)));
             }
           }
-        } else {
-          // no body is given: no brackets, but a semicolon -> abstract
         }
 
         Position classPosition = JimpleConverterUtil.buildPositionFromCtx(ctx);
@@ -584,9 +566,7 @@ public class JimpleConverter {
             }
 
             List<Immediate> sizes =
-                ctx.immediate().stream()
-                    .map(this::visitImmediate)
-                    .collect(Collectors.toList());
+                ctx.immediate().stream().map(this::visitImmediate).collect(Collectors.toList());
             if (sizes.size() < 1) {
               throw new ResolveException(
                   "The Size list must have at least one Element.",

--- a/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleConverter.java
+++ b/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleConverter.java
@@ -135,7 +135,7 @@ public class JimpleConverter {
             "Classname is not well formed.", path, JimpleConverterUtil.buildPositionFromCtx(ctx));
       }
 
-      modifiers = getClassModifiers(ctx.modifier());
+      modifiers = getClassModifiers(ctx.class_modifier());
       // file_type
       if (ctx.file_type() != null) {
         if (ctx.file_type().getText().equals("interface")) {
@@ -177,7 +177,7 @@ public class JimpleConverter {
 
         } else {
           final JimpleParser.FieldContext fieldCtx = ctx.member(i).field();
-          EnumSet<FieldModifier> modifier = getFieldModifiers(fieldCtx.modifier());
+          EnumSet<FieldModifier> modifier = getFieldModifiers(fieldCtx.field_modifier());
           final Position pos = JimpleConverterUtil.buildPositionFromCtx(fieldCtx);
           final String fieldName = Jimple.unescape(fieldCtx.identifier().getText());
           final SootField f =
@@ -196,20 +196,22 @@ public class JimpleConverter {
       return true;
     }
 
-    private EnumSet<ClassModifier> getClassModifiers(List<JimpleParser.ModifierContext> modifier) {
+    private EnumSet<ClassModifier> getClassModifiers(
+        List<JimpleParser.Class_modifierContext> modifier) {
       return modifier.stream()
           .map(modContext -> ClassModifier.valueOf(modContext.getText().toUpperCase()))
           .collect(Collectors.toCollection(() -> EnumSet.noneOf(ClassModifier.class)));
     }
 
     private EnumSet<MethodModifier> getMethodModifiers(
-        List<JimpleParser.ModifierContext> modifier) {
+        List<JimpleParser.Method_modifierContext> modifier) {
       return modifier.stream()
           .map(modContext -> MethodModifier.valueOf(modContext.getText().toUpperCase()))
           .collect(Collectors.toCollection(() -> EnumSet.noneOf(MethodModifier.class)));
     }
 
-    private EnumSet<FieldModifier> getFieldModifiers(List<JimpleParser.ModifierContext> modifier) {
+    private EnumSet<FieldModifier> getFieldModifiers(
+        List<JimpleParser.Field_modifierContext> modifier) {
       return modifier.stream()
           .map(modContext -> FieldModifier.valueOf(modContext.getText().toUpperCase()))
           .collect(Collectors.toCollection(() -> EnumSet.noneOf(FieldModifier.class)));
@@ -231,9 +233,9 @@ public class JimpleConverter {
       public SootMethod visitMethod(@Nonnull JimpleParser.MethodContext ctx) {
 
         EnumSet<MethodModifier> modifier =
-            ctx.modifier() == null
+            ctx.method_modifier() == null
                 ? EnumSet.noneOf(MethodModifier.class)
-                : getMethodModifiers(ctx.modifier());
+                : getMethodModifiers(ctx.method_modifier());
 
         final JimpleParser.Method_subsignatureContext method_subsignatureContext =
             ctx.method_subsignature();

--- a/sootup.jimple.parser/src/test/java/resources/jimple/A.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/A.jimple
@@ -1,4 +1,4 @@
-abstract synchronized class A extends java.lang.Object
+abstract super class A extends java.lang.Object
 {
     abstract void a();
     void <init>()

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AbstractClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AbstractClass.jimple
@@ -1,4 +1,4 @@
-public synchronized class AbstractClass extends A
+public super class AbstractClass extends A
 {
 
     void a()

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AccessArrays.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AccessArrays.jimple
@@ -1,4 +1,4 @@
-public synchronized class AccessArrays extends java.lang.Object
+public super class AccessArrays extends java.lang.Object
 {
     public void doubleArrays()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AlphaBetaGamma.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AlphaBetaGamma.jimple
@@ -1,4 +1,4 @@
-public class AlphaBetaGamma extends java.lang.Object
+public super class AlphaBetaGamma extends java.lang.Object
 {
 
     public void αβγ()

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AnonymousClassInsideMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AnonymousClassInsideMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class AnonymousClassInsideMethod extends java.lang.Object
+public super class AnonymousClassInsideMethod extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AnonymousDiamondOperator.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AnonymousDiamondOperator.jimple
@@ -1,4 +1,4 @@
-public synchronized class AnonymousDiamondOperator extends java.lang.Object
+public super class AnonymousDiamondOperator extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AssertStatement.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AssertStatement.jimple
@@ -1,4 +1,4 @@
-public synchronized class AssertStatement extends java.lang.Object
+public super class AssertStatement extends java.lang.Object
 {
     static final boolean $assertionsDisabled;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/Autoboxing.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/Autoboxing.jimple
@@ -1,4 +1,4 @@
-public synchronized class Autoboxing extends java.lang.Object
+public super class Autoboxing extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/AutomaticWidening.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/AutomaticWidening.jimple
@@ -1,4 +1,4 @@
-public synchronized class AutomaticWidening extends java.lang.Object
+public super class AutomaticWidening extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/BinaryLiteralInInt.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/BinaryLiteralInInt.jimple
@@ -1,4 +1,4 @@
-public synchronized class BinaryLiteralInInt extends java.lang.Object
+public super class BinaryLiteralInInt extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/BitwiseOperationsInt.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/BitwiseOperationsInt.jimple
@@ -1,4 +1,4 @@
-public synchronized class BitwiseOperationsInt extends java.lang.Object
+public super class BitwiseOperationsInt extends java.lang.Object
 {
     public void bitwiseOpOr()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/BooleanOperators.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/BooleanOperators.jimple
@@ -1,4 +1,4 @@
-public synchronized class BooleanOperators extends java.lang.Object
+public super class BooleanOperators extends java.lang.Object
 {
     public void complementOp()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/BreakInWhileLoop.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/BreakInWhileLoop.jimple
@@ -1,4 +1,4 @@
-public synchronized class BreakInWhileLoop extends java.lang.Object
+public super class BreakInWhileLoop extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/CastingInNumTypes.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/CastingInNumTypes.jimple
@@ -1,4 +1,4 @@
-synchronized class CastingInNumTypes extends java.lang.Object
+super class CastingInNumTypes extends java.lang.Object
 {
     public void displayNum()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/CharLiterals.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/CharLiterals.jimple
@@ -1,4 +1,4 @@
-public synchronized class CharLiterals extends java.lang.Object
+public super class CharLiterals extends java.lang.Object
 {
     public void specialChar()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/ContinueInWhileLoop.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/ContinueInWhileLoop.jimple
@@ -1,4 +1,4 @@
-public synchronized class ContinueInWhileLoop extends java.lang.Object
+public super class ContinueInWhileLoop extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/CreateNewInstance.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/CreateNewInstance.jimple
@@ -1,4 +1,4 @@
-public synchronized class CreateNewInstance extends java.lang.Object
+public super class CreateNewInstance extends java.lang.Object
 {
     public void createNewInstance()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareConstructor.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareConstructor.jimple
@@ -1,4 +1,4 @@
-synchronized class DeclareConstructor extends java.lang.Object
+super class DeclareConstructor extends java.lang.Object
 {
     public int var1;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareEnum$Type.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareEnum$Type.jimple
@@ -1,4 +1,4 @@
-public final synchronized enum class DeclareEnum$Type extends java.lang.Enum
+public final super enum class DeclareEnum$Type extends java.lang.Enum
 {
     public static final enum DeclareEnum$Type TYPE3;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareEnumWithConstructor$Number.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareEnumWithConstructor$Number.jimple
@@ -1,4 +1,4 @@
-public final synchronized enum class DeclareEnumWithConstructor$Number extends java.lang.Enum
+public final super enum class DeclareEnumWithConstructor$Number extends java.lang.Enum
 {
     public static final enum DeclareEnumWithConstructor$Number ONE;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareField.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareField.jimple
@@ -1,4 +1,4 @@
-synchronized class DeclareField extends java.lang.Object
+super class DeclareField extends java.lang.Object
 {
     public final java.lang.String s;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareFloat.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareFloat.jimple
@@ -1,4 +1,4 @@
-public synchronized class DeclareFloat extends java.lang.Object
+public super class DeclareFloat extends java.lang.Object
 {
     float f1;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareInnerClass$InnerClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareInnerClass$InnerClass.jimple
@@ -1,4 +1,4 @@
-public synchronized class DeclareInnerClass$InnerClass extends java.lang.Object
+public super class DeclareInnerClass$InnerClass extends java.lang.Object
 {
     final DeclareInnerClass this$0;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareInnerClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareInnerClass.jimple
@@ -1,4 +1,4 @@
-synchronized class DeclareInnerClass extends java.lang.Object
+super class DeclareInnerClass extends java.lang.Object
 {
     public int a;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareInt.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareInt.jimple
@@ -1,4 +1,4 @@
-public synchronized class DeclareInt extends java.lang.Object
+public super class DeclareInt extends java.lang.Object
 {
     int hex;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DeclareLong.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DeclareLong.jimple
@@ -1,4 +1,4 @@
-public synchronized class DeclareLong extends java.lang.Object
+public super class DeclareLong extends java.lang.Object
 {
     long l1;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DefaultMethodInterfaceImpl.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DefaultMethodInterfaceImpl.jimple
@@ -1,4 +1,4 @@
-synchronized class DefaultMethodInterfaceImpl extends java.lang.Object implements DefaultMethodInterface
+super class DefaultMethodInterfaceImpl extends java.lang.Object implements DefaultMethodInterface
 {
     public void interfaceMethod()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DoWhileLoop.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DoWhileLoop.jimple
@@ -1,4 +1,4 @@
-public synchronized class DoWhileLoop extends java.lang.Object
+public super class DoWhileLoop extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/DynamicInvoke.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/DynamicInvoke.jimple
@@ -1,4 +1,4 @@
-public synchronized class DynamicInvoke extends java.lang.Object
+public super class DynamicInvoke extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/EmptyStatement.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/EmptyStatement.jimple
@@ -1,4 +1,4 @@
-public synchronized class EmptyStatement extends java.lang.Object
+public super class EmptyStatement extends java.lang.Object
 {
     public void emptyStatement()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/EscapeSequencesInString.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/EscapeSequencesInString.jimple
@@ -1,4 +1,4 @@
-public synchronized class EscapeSequencesInString extends java.lang.Object
+public super class EscapeSequencesInString extends java.lang.Object
 {
     public void escapeBackslashB()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/EvaluationOrderWithParentheses.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/EvaluationOrderWithParentheses.jimple
@@ -1,4 +1,4 @@
-public synchronized class EvaluationOrderWithParentheses extends java.lang.Object
+public super class EvaluationOrderWithParentheses extends java.lang.Object
 {
     public void evaluationOrderWithParentheses()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/FinalMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/FinalMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class FinalMethod extends java.lang.Object
+public super class FinalMethod extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/FinalVariable.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/FinalVariable.jimple
@@ -1,4 +1,4 @@
-public synchronized class FinalVariable extends java.lang.Object
+public super class FinalVariable extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/ForEachLoop.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/ForEachLoop.jimple
@@ -1,4 +1,4 @@
-public synchronized class ForEachLoop extends java.lang.Object
+public super class ForEachLoop extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/ForLoop.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/ForLoop.jimple
@@ -1,4 +1,4 @@
-public synchronized class ForLoop extends java.lang.Object
+public super class ForLoop extends java.lang.Object
 {
     public void forLoop()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/GenTypeParam.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/GenTypeParam.jimple
@@ -1,4 +1,4 @@
-synchronized class GenTypeParam extends java.lang.Object
+super class GenTypeParam extends java.lang.Object
 {
     public java.lang.Number largestNum(java.lang.Number,java.lang.Number,java.lang.Number)
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/GenericTypeParamOnClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/GenericTypeParamOnClass.jimple
@@ -1,4 +1,4 @@
-public synchronized class GenericTypeParamOnClass extends java.lang.Object
+public super class GenericTypeParamOnClass extends java.lang.Object
 {
     public void genericTypeParamOnClass()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/GenericTypeParamOnMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/GenericTypeParamOnMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class GenericTypeParamOnMethod extends java.lang.Object
+public super class GenericTypeParamOnMethod extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/IfElseStatement.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/IfElseStatement.jimple
@@ -1,4 +1,4 @@
-public synchronized class IfElseStatement extends java.lang.Object
+public super class IfElseStatement extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/InfiniteLoop.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/InfiniteLoop.jimple
@@ -1,4 +1,4 @@
-synchronized class InfiniteLoop extends java.lang.Object
+super class InfiniteLoop extends java.lang.Object
 {
     void stmtLoop()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/Initialize3DimensionalArrays.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/Initialize3DimensionalArrays.jimple
@@ -1,4 +1,4 @@
-public synchronized class Initialize3DimensionalArrays extends java.lang.Object
+public super class Initialize3DimensionalArrays extends java.lang.Object
 {
     public void shortArrays()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/InitializeArraysWhileDeclaration.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/InitializeArraysWhileDeclaration.jimple
@@ -1,4 +1,4 @@
-public synchronized class InitializeArraysWhileDeclaration extends java.lang.Object
+public super class InitializeArraysWhileDeclaration extends java.lang.Object
 {
     public void intArrays()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/InitializeArraysWithIndex.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/InitializeArraysWithIndex.jimple
@@ -1,4 +1,4 @@
-public synchronized class InitializeArraysWithIndex extends java.lang.Object
+public super class InitializeArraysWithIndex extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/InitializeMultidimensionalArrays.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/InitializeMultidimensionalArrays.jimple
@@ -1,4 +1,4 @@
-public synchronized class InitializeMultidimensionalArrays extends java.lang.Object
+public super class InitializeMultidimensionalArrays extends java.lang.Object
 {
     public void doubleArrays()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/InstanceOfCheck.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/InstanceOfCheck.jimple
@@ -1,4 +1,4 @@
-synchronized class InstanceOfCheck extends InstanceOfCheckSuper
+super class InstanceOfCheck extends InstanceOfCheckSuper
 {
     public void instanceOfCheckMethod()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/InterfaceImplClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/InterfaceImplClass.jimple
@@ -1,4 +1,4 @@
-synchronized class InterfaceImplClass extends java.lang.Object implements InterfaceImpl
+super class InterfaceImplClass extends java.lang.Object implements InterfaceImpl
 {
     void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/LabelStatement.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/LabelStatement.jimple
@@ -1,4 +1,4 @@
-public synchronized class LabelStatement extends java.lang.Object
+public super class LabelStatement extends java.lang.Object
 {
     public void labelStatement()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/LabelledLoopBreak.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/LabelledLoopBreak.jimple
@@ -1,4 +1,4 @@
-public synchronized class LabelledLoopBreak extends java.lang.Object
+public super class LabelledLoopBreak extends java.lang.Object
 {
     public void labelledLoopBreak()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MethodAcceptingLamExpr.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MethodAcceptingLamExpr.jimple
@@ -1,4 +1,4 @@
-public synchronized class MethodAcceptingLamExpr extends java.lang.Object
+public super class MethodAcceptingLamExpr extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MethodAcceptingVar.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MethodAcceptingVar.jimple
@@ -1,4 +1,4 @@
-public synchronized class MethodAcceptingVar extends java.lang.Object
+public super class MethodAcceptingVar extends java.lang.Object
 {
     public void intVariable(int)
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MethodOverloading.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MethodOverloading.jimple
@@ -1,4 +1,4 @@
-synchronized class MethodOverloading extends java.lang.Object
+super class MethodOverloading extends java.lang.Object
 {
     int calculate(int)
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MethodOverridingSubclass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MethodOverridingSubclass.jimple
@@ -1,4 +1,4 @@
-public synchronized class MethodOverridingSubclass extends MethodOverriding
+public super class MethodOverridingSubclass extends MethodOverriding
 {
     public void calculateArea()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MethodReference.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MethodReference.jimple
@@ -1,4 +1,4 @@
-public synchronized class MethodReference extends java.lang.Object
+public super class MethodReference extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MethodReturningVar.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MethodReturningVar.jimple
@@ -1,4 +1,4 @@
-public synchronized class MethodReturningVar extends java.lang.Object
+public super class MethodReturningVar extends java.lang.Object
 {
     public long longVariable()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MultiInterfaceImplClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MultiInterfaceImplClass.jimple
@@ -1,4 +1,4 @@
-synchronized class MultiInterfaceImplClass extends java.lang.Object implements InterfaceImplDummy, InterfaceImpl
+super class MultiInterfaceImplClass extends java.lang.Object implements InterfaceImplDummy, InterfaceImpl
 {
     public void interfaceMethod()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/MultiTryCatch.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/MultiTryCatch.jimple
@@ -1,4 +1,4 @@
-synchronized class MultiTryCatch extends java.lang.Object
+super class MultiTryCatch extends java.lang.Object
 {
     public void printFile() throws java.lang.Exception
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/NamedClassInsideMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/NamedClassInsideMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class NamedClassInsideMethod extends java.lang.Object
+public super class NamedClassInsideMethod extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/NativeMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/NativeMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class NativeMethod extends java.lang.Object
+public super class NativeMethod extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/NewCodeBlockInMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/NewCodeBlockInMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class NewCodeBlockInMethod extends java.lang.Object
+public super class NewCodeBlockInMethod extends java.lang.Object
 {
     public void newCodeBlockInMethod()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/NoModifierClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/NoModifierClass.jimple
@@ -1,4 +1,4 @@
-synchronized class NoModifierClass extends java.lang.Object
+super class NoModifierClass extends java.lang.Object
 {
     void noModifierMethod()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/NullVariable.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/NullVariable.jimple
@@ -1,4 +1,4 @@
-public synchronized class NullVariable extends java.lang.Object
+public super class NullVariable extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/PrivateMethodInterfaceImpl.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/PrivateMethodInterfaceImpl.jimple
@@ -1,4 +1,4 @@
-public synchronized class PrivateMethodInterfaceImpl extends java.lang.Object implements PrivateMethodInterface
+public super class PrivateMethodInterfaceImpl extends java.lang.Object implements PrivateMethodInterface
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/PublicClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/PublicClass.jimple
@@ -1,4 +1,4 @@
-public synchronized class PublicClass extends java.lang.Object
+public super class PublicClass extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/ReferenceVarDeclaration.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/ReferenceVarDeclaration.jimple
@@ -1,4 +1,4 @@
-public synchronized class ReferenceVarDeclaration extends java.lang.Object
+public super class ReferenceVarDeclaration extends java.lang.Object
 {
     public void stringVariable()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/ReferencingThis.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/ReferencingThis.jimple
@@ -1,4 +1,4 @@
-synchronized class ReferencingThis extends java.lang.Object
+super class ReferencingThis extends java.lang.Object
 {
     int b;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/Reflection.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/Reflection.jimple
@@ -1,4 +1,4 @@
-public synchronized class Reflection extends java.lang.Object
+public super class Reflection extends java.lang.Object
 {
     private java.lang.String s;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StatementEval.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StatementEval.jimple
@@ -1,4 +1,4 @@
-public synchronized class StatementEval extends java.lang.Object
+public super class StatementEval extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StaticImport.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StaticImport.jimple
@@ -1,4 +1,4 @@
-synchronized class StaticImport extends java.lang.Object
+super class StaticImport extends java.lang.Object
 {
     public static void main(java.lang.String[])
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StaticInitializer.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StaticInitializer.jimple
@@ -1,4 +1,4 @@
-public synchronized class StaticInitializer extends java.lang.Object
+public super class StaticInitializer extends java.lang.Object
 {
     static int i;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StaticMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StaticMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class StaticMethod extends java.lang.Object
+public super class StaticMethod extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StaticMethodInterfaceImpl.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StaticMethodInterfaceImpl.jimple
@@ -1,4 +1,4 @@
-synchronized class StaticMethodInterfaceImpl extends java.lang.Object implements StaticMethodInterface
+super class StaticMethodInterfaceImpl extends java.lang.Object implements StaticMethodInterface
 {
     public static void initStatic()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StaticMethodInvocation.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StaticMethodInvocation.jimple
@@ -1,4 +1,4 @@
-public synchronized class StaticMethodInvocation extends java.lang.Object
+public super class StaticMethodInvocation extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StaticVariable.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StaticVariable.jimple
@@ -1,4 +1,4 @@
-public synchronized class StaticVariable extends java.lang.Object
+public super class StaticVariable extends java.lang.Object
 {
     static int num;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StringConcatenation.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StringConcatenation.jimple
@@ -1,4 +1,4 @@
-public synchronized class StringConcatenation extends java.lang.Object
+public super class StringConcatenation extends java.lang.Object
 {
     public void stringConcatenation()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/StringWithUnicodeChar.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/StringWithUnicodeChar.jimple
@@ -1,4 +1,4 @@
-public synchronized class StringWithUnicodeChar extends java.lang.Object
+public super class StringWithUnicodeChar extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/SubClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/SubClass.jimple
@@ -1,4 +1,4 @@
-synchronized class SubClass extends SuperClass
+super class SubClass extends SuperClass
 {
     int cc;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/SuperClass.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/SuperClass.jimple
@@ -1,4 +1,4 @@
-synchronized class SuperClass extends java.lang.Object
+super class SuperClass extends java.lang.Object
 {
     int c;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/SwitchCaseStatement.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/SwitchCaseStatement.jimple
@@ -1,4 +1,4 @@
-public synchronized class SwitchCaseStatement extends java.lang.Object
+public super class SwitchCaseStatement extends java.lang.Object
 {
     public void switchCaseGroupedTargetsDefault()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/SwitchCaseStatementWithString.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/SwitchCaseStatementWithString.jimple
@@ -1,4 +1,4 @@
-public synchronized class SwitchCaseStatementWithString extends java.lang.Object
+public super class SwitchCaseStatementWithString extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/SymbolsAsMethodName.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/SymbolsAsMethodName.jimple
@@ -1,4 +1,4 @@
-public synchronized class SymbolsAsMethodName extends java.lang.Object
+public super class SymbolsAsMethodName extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/SynchronizedBlock.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/SynchronizedBlock.jimple
@@ -1,4 +1,4 @@
-public synchronized class SynchronizedBlock extends java.lang.Object
+public super class SynchronizedBlock extends java.lang.Object
 {
     private java.lang.String msg;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/SynchronizedMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/SynchronizedMethod.jimple
@@ -1,4 +1,4 @@
-public synchronized class SynchronizedMethod extends java.lang.Object
+public super class SynchronizedMethod extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/TernaryOperator.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/TernaryOperator.jimple
@@ -1,4 +1,4 @@
-public synchronized class TernaryOperator extends java.lang.Object
+public super class TernaryOperator extends java.lang.Object
 {
     int num;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/ThrowExceptionMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/ThrowExceptionMethod.jimple
@@ -1,4 +1,4 @@
-synchronized class ThrowExceptionMethod extends java.lang.Object
+super class ThrowExceptionMethod extends java.lang.Object
 {
     public static void main(java.lang.String[])
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/TransientVariable.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/TransientVariable.jimple
@@ -1,4 +1,4 @@
-synchronized class TransientVariable extends java.lang.Object
+super class TransientVariable extends java.lang.Object
 {
     transient int transientVar;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/TryCatchFinally.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/TryCatchFinally.jimple
@@ -1,4 +1,4 @@
-public synchronized class TryCatchFinally extends java.lang.Object
+public super class TryCatchFinally extends java.lang.Object
 {
     public void tryCatch()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/TryWithResources.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/TryWithResources.jimple
@@ -1,4 +1,4 @@
-synchronized class TryWithResources extends java.lang.Object
+super class TryWithResources extends java.lang.Object
 {
     void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/TryWithResourcesConcise.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/TryWithResourcesConcise.jimple
@@ -1,4 +1,4 @@
-public synchronized class TryWithResourcesConcise extends java.lang.Object
+public super class TryWithResourcesConcise extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/TypeInference.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/TypeInference.jimple
@@ -1,4 +1,4 @@
-synchronized class TypeInference extends java.lang.Object
+super class TypeInference extends java.lang.Object
 {
     void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/UnaryOpInt.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/UnaryOpInt.jimple
@@ -1,4 +1,4 @@
-synchronized class UnaryOpInt extends java.lang.Object
+super class UnaryOpInt extends java.lang.Object
 {
     int i;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/UncheckedCast.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/UncheckedCast.jimple
@@ -1,4 +1,4 @@
-synchronized class UncheckedCast extends java.lang.Object
+super class UncheckedCast extends java.lang.Object
 {
     void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/UnderscoreInInt.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/UnderscoreInInt.jimple
@@ -1,4 +1,4 @@
-public synchronized class UnderscoreInInt extends java.lang.Object
+public super class UnderscoreInInt extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/VariableDeclaration.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/VariableDeclaration.jimple
@@ -1,4 +1,4 @@
-public synchronized class VariableDeclaration extends java.lang.Object
+public super class VariableDeclaration extends java.lang.Object
 {
     public void shortVariable()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/VariableShadowing.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/VariableShadowing.jimple
@@ -1,4 +1,4 @@
-public synchronized class VariableShadowing extends java.lang.Object
+public super class VariableShadowing extends java.lang.Object
 {
     int num;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/VirtualMethod.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/VirtualMethod.jimple
@@ -1,4 +1,4 @@
-synchronized class VirtualMethod extends java.lang.Object
+super class VirtualMethod extends java.lang.Object
 {
     public static void main(java.lang.String[])
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/VolatileVariable.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/VolatileVariable.jimple
@@ -1,4 +1,4 @@
-synchronized class VolatileVariable extends java.lang.Object
+super class VolatileVariable extends java.lang.Object
 {
     public volatile int counter;
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/WhileLoop.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/WhileLoop.jimple
@@ -1,4 +1,4 @@
-public synchronized class WhileLoop extends java.lang.Object
+public super class WhileLoop extends java.lang.Object
 {
     public void whileLoop()
     {

--- a/sootup.jimple.parser/src/test/java/resources/jimple/αρετη.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/αρετη.jimple
@@ -1,4 +1,4 @@
-public synchronized class \u03b1\u03c1\u03b5\u03c4\u03b7 extends java.lang.Object
+public super class \u03b1\u03c1\u03b5\u03c4\u03b7 extends java.lang.Object
 {
     public void <init>()
     {

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/AnnotationLibraryTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/AnnotationLibraryTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.jimple.parser.categories.Java8Test;
 import sootup.jimple.parser.javatestsuite.JimpleTestSuiteBase;
@@ -18,6 +18,6 @@ public class AnnotationLibraryTest extends JimpleTestSuiteBase {
     // TODO: annotations are not supported yet
     System.out.println(getDeclaredClassSignature());
     SootClass sootClass = loadClass(getDeclaredClassSignature());
-    assertTrue(Modifier.isAnnotation(sootClass.getModifiers()));
+    assertTrue(ClassModifier.isAnnotation(sootClass.getModifiers()));
   }
 }

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/DeclareFieldTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/DeclareFieldTest.java
@@ -41,15 +41,17 @@ public class DeclareFieldTest extends JimpleTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getModifiers().contains(FieldModifier.PRIVATE)
-                    && sootField.getModifiers().contains(FieldModifier.STATIC)
-                    && sootField.getName().equals("i")));
+                sootField ->
+                    sootField.getModifiers().contains(FieldModifier.PRIVATE)
+                        && sootField.getModifiers().contains(FieldModifier.STATIC)
+                        && sootField.getName().equals("i")));
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getModifiers().contains(FieldModifier.PUBLIC)
-                    && sootField.getModifiers().contains(FieldModifier.FINAL)
-                    && sootField.getName().equals("s")));
+                sootField ->
+                    sootField.getModifiers().contains(FieldModifier.PUBLIC)
+                        && sootField.getModifiers().contains(FieldModifier.FINAL)
+                        && sootField.getName().equals("s")));
   }
 
   public List<String> expectedBodyStmts() {

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/DeclareFieldTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/DeclareFieldTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -41,19 +41,15 @@ public class DeclareFieldTest extends JimpleTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getModifiers().contains(Modifier.PRIVATE)
-                      && sootField.getModifiers().contains(Modifier.STATIC)
-                      && sootField.getName().equals("i");
-                }));
+                sootField -> sootField.getModifiers().contains(FieldModifier.PRIVATE)
+                    && sootField.getModifiers().contains(FieldModifier.STATIC)
+                    && sootField.getName().equals("i")));
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getModifiers().contains(Modifier.PUBLIC)
-                      && sootField.getModifiers().contains(Modifier.FINAL)
-                      && sootField.getName().equals("s");
-                }));
+                sootField -> sootField.getModifiers().contains(FieldModifier.PUBLIC)
+                    && sootField.getModifiers().contains(FieldModifier.FINAL)
+                    && sootField.getName().equals("s")));
   }
 
   public List<String> expectedBodyStmts() {

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/PublicClassTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/PublicClassTest.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -24,7 +24,7 @@ public class PublicClassTest extends JimpleTestSuiteBase {
   @Test
   public void test() {
     SootClass<?> clazz = loadClass(getDeclaredClassSignature());
-    assertEquals(EnumSet.of(Modifier.PUBLIC, Modifier.SYNCHRONIZED), clazz.getModifiers());
+    assertEquals(EnumSet.of(ClassModifier.PUBLIC, ClassModifier.SUPER), clazz.getModifiers());
 
     SootMethod method;
     method = clazz.getMethod(getMethodSignature("private").getSubSignature()).get();

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/TransientVariableTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/TransientVariableTest.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -34,7 +34,7 @@ public class TransientVariableTest extends JimpleTestSuiteBase {
             .anyMatch(
                 sootField ->
                     sootField.getName().equals("transientVar")
-                        && sootField.getModifiers().contains(Modifier.TRANSIENT)));
+                        && sootField.getModifiers().contains(FieldModifier.TRANSIENT)));
   }
 
   public List<String> expectedBodyStmts() {

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/VolatileVariableTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/VolatileVariableTest.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.FieldModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -32,10 +32,8 @@ public class VolatileVariableTest extends JimpleTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> {
-                  return sootField.getName().equals("counter")
-                      && sootField.getModifiers().contains(Modifier.VOLATILE);
-                }));
+                sootField -> sootField.getName().equals("counter")
+                    && sootField.getModifiers().contains(FieldModifier.VOLATILE)));
   }
 
   public List<String> expectedBodyStmts() {

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/VolatileVariableTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java6/VolatileVariableTest.java
@@ -32,8 +32,9 @@ public class VolatileVariableTest extends JimpleTestSuiteBase {
     assertTrue(
         clazz.getFields().stream()
             .anyMatch(
-                sootField -> sootField.getName().equals("counter")
-                    && sootField.getModifiers().contains(FieldModifier.VOLATILE)));
+                sootField ->
+                    sootField.getName().equals("counter")
+                        && sootField.getModifiers().contains(FieldModifier.VOLATILE)));
   }
 
   public List<String> expectedBodyStmts() {

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java8/RepeatingAnnotationsTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/javatestsuite/java8/RepeatingAnnotationsTest.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
@@ -31,7 +31,7 @@ public class RepeatingAnnotationsTest extends JimpleTestSuiteBase {
     SootMethod method = loadMethod(getMethodSignature());
     assertJimpleStmts(method, expectedBodyStmts());
     SootClass sootClass = loadClass(getDeclaredClassSignature());
-    assertTrue(Modifier.isAnnotation(sootClass.getModifiers()));
+    assertTrue(ClassModifier.isAnnotation(sootClass.getModifiers()));
   }
 
   public List<String> expectedBodyStmts() {

--- a/sootup.tests/src/test/java/sootup/tests/MutableSootClientTest.java
+++ b/sootup.tests/src/test/java/sootup/tests/MutableSootClientTest.java
@@ -79,7 +79,7 @@ public class MutableSootClientTest {
             Collections.emptySet(),
             Collections.emptySet(),
             new FullPosition(0, 0, 0, 0),
-            EnumSet.noneOf(Modifier.class),
+            EnumSet.noneOf(ClassModifier.class),
             Collections.emptySet(),
             Collections.emptySet(),
             Collections.emptySet());
@@ -136,7 +136,7 @@ public class MutableSootClientTest {
         new JavaSootMethod(
             new OverridingBodySource(methodSignature, body),
             methodSignature,
-            EnumSet.of(Modifier.PUBLIC, Modifier.STATIC),
+            EnumSet.of(MethodModifier.PUBLIC, MethodModifier.STATIC),
             Collections.emptyList(),
             Collections.emptyList(),
             NoPositionInformation.getInstance());

--- a/sootup.tests/src/test/java/sootup/tests/typehierarchy/ViewTypeHierarchyTest.java
+++ b/sootup.tests/src/test/java/sootup/tests/typehierarchy/ViewTypeHierarchyTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import sootup.core.IdentifierFactory;
-import sootup.core.model.Modifier;
+import sootup.core.model.ClassModifier;
 import sootup.core.model.SootClass;
 import sootup.core.model.SourceType;
 import sootup.core.typehierarchy.ViewTypeHierarchy;
@@ -202,7 +202,7 @@ public class ViewTypeHierarchyTest {
             Collections.emptySet(),
             Collections.emptySet(),
             null,
-            EnumSet.of(Modifier.FINAL),
+            EnumSet.of(ClassModifier.FINAL),
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList());


### PR DESCRIPTION
Fields, Classes and Methods have modfiers which have the same bytecode but different meanings
fixes #630 
introduces API changes since Modifier is split to different Enums