### PR TITLE
Update PathBasedAnalysisInputLocation.java

### DIFF
--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/PathBasedAnalysisInputLocation.java
@@ -197,6 +197,7 @@ public class PathBasedAnalysisInputLocation implements AnalysisInputLocation<Jav
           .filter(
               filePath ->
                   PathUtils.hasExtension(filePath, handledFileType)
+                  && filePath.toString().endsWith("." + handledFileType.getExtension())
                       && !filePath.toString().endsWith(moduleInfoFilename))
           .flatMap(
               p ->


### PR DESCRIPTION
If this condition is not added when using SootUp to analyze this Artifact (**org.apache.dubbo:dubbo:3.1.4**),  the following error will be reported. The reason for the error is mistaking the **DENY_CLASS** in org.apache.dubbo:dubbo:3.1.4 as a *.class file.
![image](https://github.com/soot-oss/SootUp/assets/126549527/fb30496a-98a3-433b-9017-2ace5231ba1e)
![image](https://github.com/soot-oss/SootUp/assets/126549527/e15de576-c336-4dfe-83a8-620f76f8e207)
