### PR TITLE
Don't throw execption when class not found in resolveConcreteDispatch

### DIFF
--- a/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
+++ b/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
@@ -184,7 +184,7 @@ public final class MethodDispatchResolver {
     TypeHierarchy hierarchy = view.getTypeHierarchy();
     ClassType superClassType = m.getDeclClassType();
     SootClass<?> startClass = view.getClass(superClassType).orElse(null);
-    ArrayList<SootClass<?>> classesInHierachyOrder = new ArrayList<>();
+    ArrayList<SootClass<?>> classesInHierarchyOrder = new ArrayList<>();
 
     // search concrete method in the class itself and its super classes
     do {
@@ -196,7 +196,7 @@ public final class MethodDispatchResolver {
                       new ResolveException(
                           "Did not find class " + finalSuperClassType + " in View"));
 
-      classesInHierachyOrder.add(superClass);
+      classesInHierarchyOrder.add(superClass);
 
       SootMethod concreteMethod = superClass.getMethod(m.getSubSignature()).orElse(null);
       if (concreteMethod != null && !concreteMethod.isAbstract()) {
@@ -209,7 +209,7 @@ public final class MethodDispatchResolver {
           // A not implemented method of an abstract class results into an abstract method
           return Optional.empty();
         }
-        // found method is abstract and the startclass is not abstract
+        // found method is abstract and the start class is not abstract
         throw new ResolveException(
             "Could not find concrete method for " + m + " because the method is abstract");
       }
@@ -220,7 +220,7 @@ public final class MethodDispatchResolver {
     // No super class contains the implemented method, search the concrete method in interfaces
     // first collect all interfaces and super interfaces
     List<SootClass<?>> worklist =
-        classesInHierachyOrder.stream()
+            classesInHierarchyOrder.stream()
             .flatMap(sootClass -> getSootClassesOfInterfaces(view, sootClass).stream())
             .collect(Collectors.toList());
     ArrayList<SootClass<?>> processedInterface = new ArrayList<>();

--- a/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
+++ b/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
@@ -201,20 +201,21 @@ public final class MethodDispatchResolver {
     List<SootClass<?>> classesInHierarchyOrder = findSuperClassesInclusive(view, current);
 
     for (SootClass<?> currentClass : classesInHierarchyOrder) {
-      SootMethod concreteMethod = currentClass.getMethod(m.getSubSignature()).orElse(null);
-      if (concreteMethod != null && !concreteMethod.isAbstract()) {
-        // found method is not abstract
-        return Optional.of(concreteMethod.getSignature());
-      }
-      if (concreteMethod != null && concreteMethod.isAbstract()) {
-        if (startClass.isAbstract()
-            && !startClass.getType().equals(concreteMethod.getDeclaringClassType())) {
-          // A not implemented method of an abstract class results into an abstract method
-          return Optional.empty();
+      SootMethod method = currentClass.getMethod(m.getSubSignature()).orElse(null);
+      if (method != null) {
+        if (!method.isAbstract()) {
+          // found method is not abstract
+          return Optional.of(method.getSignature());
+        } else {
+          if (startClass.isAbstract()
+              && !startClass.getType().equals(method.getDeclaringClassType())) {
+            // A not implemented method of an abstract class results into an abstract method
+            return Optional.empty();
+          }
+          // found method is abstract and the startClass is not abstract
+          throw new ResolveException(
+              "Could not find concrete method for " + m + " because the method is abstract");
         }
-        // found method is abstract and the startClass is not abstract
-        throw new ResolveException(
-            "Could not find concrete method for " + m + " because the method is abstract");
       }
     }
 

--- a/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
+++ b/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
@@ -86,7 +86,7 @@ public final class MethodDispatchResolver {
                         () ->
                             new ResolveException(
                                 "Could not resolve " + subtype + ", but found it in hierarchy.")))
-        .map(sootClass -> findConcreteMethodInSootClass(sootClass, m))
+            .map(sootClass -> sootClass.getMethod(m.getSubSignature()))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .filter(method -> !method.isAbstract())
@@ -112,7 +112,7 @@ public final class MethodDispatchResolver {
                             new ResolveException(
                                 "Could not resolve " + subtype + ", but found it in hierarchy.")))
         .filter(c -> classes.contains(c.getType()))
-        .map(sootClass -> findConcreteMethodInSootClass(sootClass, m))
+            .map(sootClass -> sootClass.getMethod(m.getSubSignature()))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .filter(method -> !method.isAbstract())
@@ -198,7 +198,7 @@ public final class MethodDispatchResolver {
 
       classesInHierachyOrder.add(superClass);
 
-      SootMethod concreteMethod = findConcreteMethodInSootClass(superClass, m).orElse(null);
+      SootMethod concreteMethod = superClass.getMethod(m.getSubSignature()).orElse(null);
       if (concreteMethod != null && !concreteMethod.isAbstract()) {
         // found method is not abstract
         return Optional.of(concreteMethod.getSignature());
@@ -234,7 +234,7 @@ public final class MethodDispatchResolver {
 
       // add found default method to possibleDefaultMethods
       Optional<? extends SootMethod> concreteMethod =
-          findConcreteMethodInSootClass(currentInterface, m);
+              currentInterface.getMethod(m.getSubSignature());
       concreteMethod.ifPresent(possibleDefaultMethods::add);
 
       // if no default message is found search the default message in super interfaces
@@ -281,29 +281,6 @@ public final class MethodDispatchResolver {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .collect(Collectors.toList());
-  }
-
-  /**
-   * finds the concrete method in a SootClass
-   *
-   * <p>this method returns the concrete method of given method signature in a SootClass. Due to
-   * covariant, the given method signature can differ from the concrete method at the return type
-   * The method goes through all methods of the given SootClass and searches for a method which can
-   * dispatch.
-   *
-   * @param sootClass The method is searched in this SootClass
-   * @param methodSignature the signature of the searched method
-   * @return an Optional Object that can contain the found concrete method in the given SootClass
-   */
-  private static Optional<? extends SootMethod> findConcreteMethodInSootClass(
-      SootClass<?> sootClass, MethodSignature methodSignature) {
-    return sootClass.getMethods().stream()
-        .filter(
-            potentialTarget ->
-                methodSignature
-                    .getSubSignature()
-                    .equals(potentialTarget.getSignature().getSubSignature()))
-        .findAny();
   }
 
   /**

--- a/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
+++ b/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
@@ -22,6 +22,13 @@ package sootup.core.typehierarchy;
  */
 
 import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import sootup.core.frontend.ResolveException;
 import sootup.core.jimple.common.expr.JSpecialInvokeExpr;
 import sootup.core.model.Method;
@@ -30,14 +37,6 @@ import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
 import sootup.core.views.View;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class MethodDispatchResolver {
   private MethodDispatchResolver() {}
@@ -87,7 +86,7 @@ public final class MethodDispatchResolver {
                         () ->
                             new ResolveException(
                                 "Could not resolve " + subtype + ", but found it in hierarchy.")))
-            .map(sootClass -> sootClass.getMethod(m.getSubSignature()))
+        .map(sootClass -> sootClass.getMethod(m.getSubSignature()))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .filter(method -> !method.isAbstract())
@@ -113,7 +112,7 @@ public final class MethodDispatchResolver {
                             new ResolveException(
                                 "Could not resolve " + subtype + ", but found it in hierarchy.")))
         .filter(c -> classes.contains(c.getType()))
-            .map(sootClass -> sootClass.getMethod(m.getSubSignature()))
+        .map(sootClass -> sootClass.getMethod(m.getSubSignature()))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .filter(method -> !method.isAbstract())
@@ -175,16 +174,17 @@ public final class MethodDispatchResolver {
   }
 
   /**
-   * Returns all superclasses of <code>classType</code>(inclusive) up to <code>java.lang.Object</code>, which
-   * will be the last entry in the list, or till one of the superclasses is not contained in view.
+   * Returns all superclasses of <code>classType</code>(inclusive) up to <code>java.lang.Object
+   * </code>, which will be the last entry in the list, or till one of the superclasses is not
+   * contained in view.
    */
   private static List<SootClass<?>> findSuperClassesInclusive(
-          View<? extends SootClass<?>> view, ClassType classType) {
+      View<? extends SootClass<?>> view, ClassType classType) {
     return Stream.concat(
-                    Stream.of(classType),
-                    view.getTypeHierarchy().incompleteSuperClassesOf(classType).stream()
-            ).flatMap(t -> view.getClass(t).map(Stream::of).orElseGet(Stream::empty))
-            .collect(Collectors.toList());
+            Stream.of(classType),
+            view.getTypeHierarchy().incompleteSuperClassesOf(classType).stream())
+        .flatMap(t -> view.getClass(t).map(Stream::of).orElseGet(Stream::empty))
+        .collect(Collectors.toList());
   }
 
   /**
@@ -218,11 +218,10 @@ public final class MethodDispatchResolver {
       }
     }
 
-
     // No super class contains the implemented method, search the concrete method in interfaces
     // first collect all interfaces and super interfaces
     List<SootClass<?>> worklist =
-            classesInHierarchyOrder.stream()
+        classesInHierarchyOrder.stream()
             .flatMap(sootClass -> getSootClassesOfInterfaces(view, sootClass).stream())
             .collect(Collectors.toList());
     ArrayList<SootClass<?>> processedInterface = new ArrayList<>();
@@ -236,7 +235,7 @@ public final class MethodDispatchResolver {
 
       // add found default method to possibleDefaultMethods
       Optional<? extends SootMethod> concreteMethod =
-              currentInterface.getMethod(m.getSubSignature());
+          currentInterface.getMethod(m.getSubSignature());
       concreteMethod.ifPresent(possibleDefaultMethods::add);
 
       // if no default message is found search the default message in super interfaces

--- a/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
+++ b/sootup.core/src/main/java/sootup/core/typehierarchy/MethodDispatchResolver.java
@@ -22,12 +22,6 @@ package sootup.core.typehierarchy;
  */
 
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import sootup.core.frontend.ResolveException;
 import sootup.core.jimple.common.expr.JSpecialInvokeExpr;
 import sootup.core.model.Method;
@@ -36,6 +30,13 @@ import sootup.core.model.SootMethod;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
 import sootup.core.views.View;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class MethodDispatchResolver {
   private MethodDispatchResolver() {}


### PR DESCRIPTION
#705
use `incompleteSuperClassesOf` to prevent class not found