### PR TITLE
Fix some issues in `MutableBlockStmtGraph`

### DIFF
--- a/sootup.core/src/main/java/sootup/core/graph/MutableBasicBlock.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBasicBlock.java
@@ -82,12 +82,12 @@ public class MutableBasicBlock implements BasicBlock<MutableBasicBlock> {
     successorBlocks.add(block);
   }
 
-  public void removePredecessorBlock(@Nonnull MutableBasicBlock b) {
-    predecessorBlocks.remove(b);
+  public boolean removePredecessorBlock(@Nonnull MutableBasicBlock b) {
+    return predecessorBlocks.remove(b);
   }
 
-  public void removeSuccessorBlock(@Nonnull MutableBasicBlock b) {
-    successorBlocks.remove(b);
+  public boolean removeSuccessorBlock(@Nonnull MutableBasicBlock b) {
+    return successorBlocks.remove(b);
   }
 
   public void addExceptionalSuccessorBlock(@Nonnull ClassType exception, MutableBasicBlock b) {

--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
@@ -724,9 +724,9 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
 
   /**
    * Removes a Stmt from the StmtGraph.
-   * <p>
-   * It can optionally keep the flow (edges) of the statement
-   * by connecting the predecessors of the statement with successors of the statement.
+   *
+   * <p>It can optionally keep the flow (edges) of the statement by connecting the predecessors of
+   * the statement with successors of the statement.
    * Keeping the flow does not work when the statement has multiple successors.
    *
    * @param stmt the Stmt to be removed
@@ -737,7 +737,8 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
     if (keepFlow && successors(stmt).size() > 1) {
       // Branching statements can have multiple targets/successors,
       // and there is no obvious way to connect the predecessor and successors of the statement.
-      throw new IllegalArgumentException("can't remove a statement with multiple successors while keeping the flow");
+      throw new IllegalArgumentException(
+          "can't remove a statement with multiple successors while keeping the flow");
     }
 
     if (stmt == startingStmt) {
@@ -1006,7 +1007,8 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
         return false;
       }
 
-      // the removal of the edge between `from` and `to` might have created blocks that can be merged
+      // the removal of the edge between `from` and `to` might have created blocks that can be
+      // merged
       tryMergeWithPredecessorBlock(blockOfTo);
       tryMergeWithSuccessorBlock(blockOfFrom);
 
@@ -1022,11 +1024,14 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
       if (toIdx < stmtsOfBlock.size() && stmtsOfBlock.get(toIdx) == to) {
         MutableBasicBlock newBlock = blockOfFrom.splitBlockUnlinked(from, to);
         newBlock.copyExceptionalFlowFrom(blockOfFrom);
-        blockOfFrom.getSuccessors().forEach(successor -> {
-            successor.removePredecessorBlock(blockOfFrom);
-            newBlock.addSuccessorBlock(successor);
-            successor.addPredecessorBlock(newBlock);
-        });
+        blockOfFrom
+            .getSuccessors()
+            .forEach(
+                successor -> {
+                  successor.removePredecessorBlock(blockOfFrom);
+                  newBlock.addSuccessorBlock(successor);
+                  successor.addPredecessorBlock(newBlock);
+                });
         blockOfFrom.clearSuccessorBlocks();
         blocks.add(newBlock);
         newBlock.getStmts().forEach(s -> stmtToBlock.put(s, newBlock));

--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
@@ -391,11 +391,12 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
   @Override
   @Nonnull
   public Set<? extends BasicBlock<?>> getBlocks() {
-    return blocks.stream().map(ForwardingBasicBlock::new).collect(Collectors.toSet());
+    return blocks;
   }
 
   @Nonnull
   public List<? extends BasicBlock<?>> getBlocksSorted() {
+    // TODO this implementation is incorrect; it doesn't return a consistent order
     return StreamSupport.stream(
             Spliterators.spliteratorUnknownSize(blocks.iterator(), Spliterator.ORDERED), false)
         .map(ForwardingBasicBlock::new)

--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
@@ -1005,7 +1005,11 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
       if (toIdx < stmtsOfBlock.size() && stmtsOfBlock.get(toIdx) == to) {
         MutableBasicBlock newBlock = blockOfFrom.splitBlockUnlinked(from, to);
         newBlock.copyExceptionalFlowFrom(blockOfFrom);
-        blockOfFrom.getSuccessors().forEach(newBlock::addSuccessorBlock);
+        blockOfFrom.getSuccessors().forEach(successor -> {
+            successor.removePredecessorBlock(blockOfFrom);
+            newBlock.addSuccessorBlock(successor);
+            successor.addPredecessorBlock(newBlock);
+        });
         blockOfFrom.clearSuccessorBlocks();
         blocks.add(newBlock);
         newBlock.getStmts().forEach(s -> stmtToBlock.put(s, newBlock));

--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
@@ -721,54 +721,70 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
     removeNode(stmt, true);
   }
 
+  /**
+   * Removes a Stmt from the StmtGraph.
+   * <p>
+   * It can optionally keep the flow (edges) of the statement
+   * by connecting the predecessors of the statement with successors of the statement.
+   * Keeping the flow does not work when the statement has multiple successors.
+   *
+   * @param stmt the Stmt to be removed
+   * @param keepFlow flag indicating whether to keep the flow or not
+   * @throws IllegalArgumentException if keepFlow is true but the stmt has multiple successors
+   */
   public void removeNode(@Nonnull Stmt stmt, boolean keepFlow) {
-
-    MutableBasicBlock blockOfRemovedStmt = stmtToBlock.remove(stmt);
-    if (blockOfRemovedStmt == null) {
-      throw new IllegalArgumentException("Stmt is not in the StmtGraph!");
+    if (keepFlow && successors(stmt).size() > 1) {
+      // Branching statements can have multiple targets/successors,
+      // and there is no obvious way to connect the predecessor and successors of the statement.
+      throw new IllegalArgumentException("can't remove a statement with multiple successors while keeping the flow");
     }
 
     if (stmt == startingStmt) {
       startingStmt = null;
     }
 
-    final boolean isHead = blockOfRemovedStmt.getHead() == stmt;
-    final boolean isTail = blockOfRemovedStmt.getTail() == stmt;
-
-    // do edges from or to this node exist -> remove them?
-    if (isHead && !keepFlow) {
-      final MutableBasicBlock finalBlockOfRemovedStmt = blockOfRemovedStmt;
-      blockOfRemovedStmt
-          .getPredecessors()
-          .forEach(
-              b -> {
-                b.removeSuccessorBlock(finalBlockOfRemovedStmt);
-                finalBlockOfRemovedStmt.removePredecessorBlock(b);
-              });
-      blockOfRemovedStmt.clearPredecessorBlocks();
-    }
-
-    if (isTail) {
-      if (stmt.branches() && !keepFlow) {
-        blockOfRemovedStmt.clearSuccessorBlocks();
+    if (!keepFlow) {
+      for (Stmt predecessor : predecessors(stmt)) {
+        removeEdge(predecessor, stmt);
+      }
+      for (Stmt successor : successors(stmt)) {
+        removeEdge(stmt, successor);
       }
     }
 
-    // cleanup or merge blocks if necesssary (stmt itself is not removed from the block yet)
+    MutableBasicBlock blockOfRemovedStmt = stmtToBlock.remove(stmt);
+    if (blockOfRemovedStmt == null) {
+      throw new IllegalArgumentException("Stmt is not in the StmtGraph!");
+    }
+
     if (blockOfRemovedStmt.getStmtCount() > 1) {
+      // Removing the statement from the block will keep the flow automatically,
+      // because the flow inside a block is implicit (from one statement to the next)
+      // and connections between blocks are kept.
       blockOfRemovedStmt.removeStmt(stmt);
-
-      if (isHead) {
-        blockOfRemovedStmt = tryMergeWithPredecessorBlock(blockOfRemovedStmt);
-      }
-      if (isTail) {
-        tryMergeWithSuccessorBlock(blockOfRemovedStmt);
-      }
-
     } else {
       // cleanup block (i.e. remove!) as its not needed in the graph anymore if it only contains
       // stmt - which is
       // now deleted
+
+      if (keepFlow) {
+        // this is always true because of the check at the start of the method
+        assert blockOfRemovedStmt.getSuccessors().size() <= 1;
+
+        // connect predecessors to the successor of the statement to keep the flow
+        if (blockOfRemovedStmt.getSuccessors().size() == 1) {
+          MutableBasicBlock successor = blockOfRemovedStmt.getSuccessors().get(0);
+
+          for (MutableBasicBlock predecessor : blockOfRemovedStmt.getPredecessors()) {
+            predecessor.removeSuccessorBlock(blockOfRemovedStmt);
+            predecessor.addSuccessorBlock(successor);
+
+            successor.removePredecessorBlock(blockOfRemovedStmt);
+            successor.addPredecessorBlock(predecessor);
+          }
+        }
+      }
+
       blocks.remove(blockOfRemovedStmt);
       blockOfRemovedStmt.clearPredecessorBlocks();
       blockOfRemovedStmt.clearSuccessorBlocks();

--- a/sootup.core/src/main/java/sootup/core/graph/MutableStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableStmtGraph.java
@@ -96,8 +96,12 @@ public abstract class MutableStmtGraph extends StmtGraph<MutableBasicBlock> {
     setEdges(from, Arrays.asList(targets));
   }
 
-  /** removes the current outgoing flows of "from" to "targets" */
-  public abstract void removeEdge(@Nonnull Stmt from, @Nonnull Stmt to);
+  /**
+   * removes the current outgoing flows of "from" to "to"
+   *
+   * @return true if the edge existed and was removed; false if the edge didn't exist
+   */
+  public abstract boolean removeEdge(@Nonnull Stmt from, @Nonnull Stmt to);
 
   /** Modifications of exceptional flows removes all exceptional flows from "stmt" */
   public abstract void clearExceptionalEdges(@Nonnull Stmt stmt);

--- a/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
@@ -211,6 +211,7 @@ public class MutableBlockStmtGraphTest {
         Collections.singletonList(thirdNop).toString(), blocksSorted.get(2).getStmts().toString());
   }
 
+  @Test
   public void modifyStmtToBlockAtTail() {
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
     assertEquals(0, graph.getBlocksSorted().size());
@@ -247,13 +248,13 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(conditionalStmt, secondNop);
     assertEquals(2, graph.getBlocksSorted().size());
 
-    assertEquals(3, graph.getBlocksSorted().get(0).getStmts().size());
-    assertEquals(2, graph.getBlocksSorted().get(0).getPredecessors().size());
-    assertEquals(2, graph.getBlocksSorted().get(0).getSuccessors().size());
+    assertEquals(3, graph.getBlockOf(conditionalStmt).getStmts().size());
+    assertEquals(2, graph.getBlockOf(conditionalStmt).getPredecessors().size());
+    assertEquals(2, graph.getBlockOf(conditionalStmt).getSuccessors().size());
 
-    assertEquals(1, graph.getBlocksSorted().get(1).getStmts().size());
-    assertEquals(1, graph.getBlocksSorted().get(1).getPredecessors().size());
-    assertEquals(1, graph.getBlocksSorted().get(1).getSuccessors().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getStmts().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getPredecessors().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getSuccessors().size());
 
     // remove non-existing edge
     assertFalse(graph.removeEdge(firstNop, conditionalStmt));

--- a/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
@@ -201,7 +201,7 @@ public class MutableBlockStmtGraphTest {
     graph.setEdges(conditionalStmt, Arrays.asList(secondNop, thirdNop));
     assertEquals(3, graph.getBlocksSorted().size());
 
-    graph.removeNode(conditionalStmt);
+    graph.removeNode(conditionalStmt, false);
     final List<? extends BasicBlock<?>> blocksSorted = graph.getBlocksSorted();
     assertEquals(
         Collections.singletonList(firstNop).toString(), blocksSorted.get(0).getStmts().toString());

--- a/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
@@ -94,22 +94,22 @@ public class MutableBlockStmtGraphTest {
   public void addNodeTest() {
 
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
-    assertEquals(0, graph.getBlocksSorted().size());
+    assertEquals(0, graph.getBlocks().size());
     graph.addNode(firstNop);
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
 
     // test duplicate insertion of the same node
     graph.addNode(firstNop);
-    assertEquals(1, graph.getBlocksSorted().size());
-    assertEquals(1, graph.getBlocksSorted().get(0).getStmts().size());
+    assertEquals(1, graph.getBlocks().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getStmts().size());
 
     graph.addNode(secondNop);
-    assertEquals(2, graph.getBlocksSorted().size());
-    assertEquals(1, graph.getBlocksSorted().get(1).getStmts().size());
+    assertEquals(2, graph.getBlocks().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getStmts().size());
 
     graph.removeNode(firstNop);
-    assertEquals(1, graph.getBlocksSorted().size());
-    assertEquals(1, graph.getBlocksSorted().get(0).getStmts().size());
+    assertEquals(1, graph.getBlocks().size());
+    assertEquals(1, graph.getBlockOf(secondNop).getStmts().size());
 
     // removal of not existing
     try {
@@ -117,10 +117,10 @@ public class MutableBlockStmtGraphTest {
       fail("should not be reachable due to exception");
     } catch (Exception ignored) {
     }
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
 
     graph.removeNode(secondNop);
-    assertEquals(0, graph.getBlocksSorted().size());
+    assertEquals(0, graph.getBlocks().size());
   }
 
   @Test
@@ -129,10 +129,10 @@ public class MutableBlockStmtGraphTest {
     graph.setStartingStmt(firstNop);
     graph.putEdge(firstNop, secondNop);
     graph.putEdge(secondNop, thirdNop);
-    assertEquals(3, graph.getBlocksSorted().get(0).getStmts().size());
+    assertEquals(3, graph.getBlockOf(firstNop).getStmts().size());
 
     graph.removeNode(secondNop);
-    assertEquals(Arrays.asList(firstNop, thirdNop), graph.getBlocksSorted().get(0).getStmts());
+    assertEquals(Arrays.asList(firstNop, thirdNop), graph.getBlockOf(firstNop).getStmts());
   }
 
   @Test
@@ -143,7 +143,7 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(secondNop, thirdNop);
 
     graph.removeNode(thirdNop);
-    assertEquals(Arrays.asList(firstNop, secondNop), graph.getBlocksSorted().get(0).getStmts());
+    assertEquals(Arrays.asList(firstNop, secondNop), graph.getBlockOf(firstNop).getStmts());
   }
 
   @Test
@@ -156,7 +156,7 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(secondNop, thirdNop);
 
     graph.removeNode(firstNop);
-    assertEquals(Arrays.asList(secondNop, thirdNop), graph.getBlocksSorted().get(0).getStmts());
+    assertEquals(Arrays.asList(secondNop, thirdNop), graph.getBlockOf(secondNop).getStmts());
   }
 
   @Test
@@ -167,7 +167,7 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(secondNop, conditionalStmt);
 
     graph.removeNode(conditionalStmt);
-    assertEquals(Arrays.asList(firstNop, secondNop), graph.getBlocksSorted().get(0).getStmts());
+    assertEquals(Arrays.asList(firstNop, secondNop), graph.getBlockOf(firstNop).getStmts());
   }
 
   @Test
@@ -176,10 +176,10 @@ public class MutableBlockStmtGraphTest {
     graph.setStartingStmt(firstNop);
     graph.setEdges(firstNop, Collections.singletonList(conditionalStmt));
     assertEquals(
-        Arrays.asList(firstNop, conditionalStmt), graph.getBlocksSorted().get(0).getStmts());
+        Arrays.asList(firstNop, conditionalStmt), graph.getBlockOf(firstNop).getStmts());
 
     graph.setEdges(conditionalStmt, Arrays.asList(secondNop, thirdNop));
-    assertEquals(3, graph.getBlocksSorted().size());
+    assertEquals(3, graph.getBlocks().size());
 
     assertEquals(
         Arrays.asList(firstNop, conditionalStmt).toString(),
@@ -199,54 +199,53 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(firstNop, conditionalStmt);
 
     graph.setEdges(conditionalStmt, Arrays.asList(secondNop, thirdNop));
-    assertEquals(3, graph.getBlocksSorted().size());
+    assertEquals(3, graph.getBlocks().size());
 
     graph.removeNode(conditionalStmt, false);
-    final List<? extends BasicBlock<?>> blocksSorted = graph.getBlocksSorted();
     assertEquals(
-        Collections.singletonList(firstNop).toString(), blocksSorted.get(0).getStmts().toString());
+        Collections.singletonList(firstNop).toString(), graph.getBlockOf(firstNop).getStmts().toString());
     assertEquals(
-        Collections.singletonList(secondNop).toString(), blocksSorted.get(1).getStmts().toString());
+        Collections.singletonList(secondNop).toString(), graph.getBlockOf(secondNop).getStmts().toString());
     assertEquals(
-        Collections.singletonList(thirdNop).toString(), blocksSorted.get(2).getStmts().toString());
+        Collections.singletonList(thirdNop).toString(), graph.getBlockOf(thirdNop).getStmts().toString());
   }
 
   @Test
   public void modifyStmtToBlockAtTail() {
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
-    assertEquals(0, graph.getBlocksSorted().size());
+    assertEquals(0, graph.getBlocks().size());
     assertEquals(0, graph.getNodes().size());
 
     graph.addNode(firstNop);
     graph.setStartingStmt(firstNop);
     assertEquals(1, graph.getNodes().size());
-    assertEquals(1, graph.getBlocksSorted().size());
-    assertEquals(1, graph.getBlocksSorted().get(0).getStmts().size());
+    assertEquals(1, graph.getBlocks().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getStmts().size());
 
     graph.putEdge(firstNop, secondNop);
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     assertEquals(2, graph.getNodes().size());
 
     graph.putEdge(secondNop, thirdNop);
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     assertEquals(3, graph.getNodes().size());
 
     // insert branchingstmt at end
     graph.putEdge(thirdNop, conditionalStmt);
     assertEquals(4, graph.getNodes().size());
-    assertEquals(1, graph.getBlocksSorted().size());
-    assertEquals(0, graph.getBlocksSorted().get(0).getPredecessors().size());
-    assertEquals(0, graph.getBlocksSorted().get(0).getSuccessors().size());
+    assertEquals(1, graph.getBlocks().size());
+    assertEquals(0, graph.getBlockOf(firstNop).getPredecessors().size());
+    assertEquals(0, graph.getBlockOf(firstNop).getSuccessors().size());
 
     // add connection between branchingstmt and first stmt
     graph.putEdge(conditionalStmt, firstNop);
-    assertEquals(1, graph.getBlocksSorted().size());
-    assertEquals(1, graph.getBlocksSorted().get(0).getPredecessors().size());
-    assertEquals(1, graph.getBlocksSorted().get(0).getSuccessors().size());
+    assertEquals(1, graph.getBlocks().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getPredecessors().size());
+    assertEquals(1, graph.getBlockOf(firstNop).getSuccessors().size());
 
     // add connection between branchingstmt and second stmt
     graph.putEdge(conditionalStmt, secondNop);
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
 
     assertEquals(3, graph.getBlockOf(conditionalStmt).getStmts().size());
     assertEquals(2, graph.getBlockOf(conditionalStmt).getPredecessors().size());
@@ -258,11 +257,11 @@ public class MutableBlockStmtGraphTest {
 
     // remove non-existing edge
     assertFalse(graph.removeEdge(firstNop, conditionalStmt));
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
 
     // remove branchingstmt at end -> edge across blocks
     assertTrue(graph.removeEdge(conditionalStmt, firstNop));
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
 
     assertEquals(4, graph.getNodes().size());
     graph.removeNode(firstNop);
@@ -270,12 +269,12 @@ public class MutableBlockStmtGraphTest {
 
     // remove branchingstmt at head
     assertTrue(graph.removeEdge(conditionalStmt, secondNop));
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     assertEquals(3, graph.getNodes().size());
 
     graph.removeNode(secondNop);
     assertEquals(2, graph.getNodes().size());
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
   }
 
   @Test
@@ -299,13 +298,12 @@ public class MutableBlockStmtGraphTest {
 
   @Test
   public void removeStmtInBetweenBlock() {
-
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
     graph.putEdge(firstNop, secondNop);
     graph.putEdge(secondNop, thirdNop);
     graph.removeNode(secondNop);
 
-    assertEquals(graph.getBlocksSorted().get(0).getStmts(), Arrays.asList(firstNop, thirdNop));
+    assertEquals(graph.getBlockOf(firstNop).getStmts(), Arrays.asList(firstNop, thirdNop));
   }
 
   @Test
@@ -360,7 +358,7 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(conditionalStmt, secondNop);
     graph.putEdge(conditionalStmt, secondNop);
 
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
 
     assertEquals(0, graph.outDegree(secondNop));
     assertEquals(2, graph.inDegree(secondNop));
@@ -378,13 +376,13 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(conditionalStmt, secondNop);
     graph.putEdge(conditionalStmt, thirdNop);
 
-    assertEquals(3, graph.getBlocksSorted().size());
+    assertEquals(3, graph.getBlocks().size());
   }
 
   @Test
   public void addBlockDirectly() {
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
-    assertEquals(0, graph.getBlocksSorted().size());
+    assertEquals(0, graph.getBlocks().size());
 
     MutableBasicBlock blockA = new MutableBasicBlock();
     blockA.addStmt(firstNop);
@@ -394,10 +392,10 @@ public class MutableBlockStmtGraphTest {
     blockC.addStmt(thirdNop);
 
     graph.addBlock(blockA.getStmts(), Collections.emptyMap());
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
 
     graph.addBlock(blockB.getStmts(), Collections.emptyMap());
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
   }
 
   @Test
@@ -418,27 +416,27 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(firstNop, secondNop);
     graph.putEdge(secondNop, thirdNop);
 
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(1, graph.successors(secondNop).size());
 
     assertTrue(graph.removeEdge(secondNop, thirdNop));
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(secondNop).size());
 
     assertFalse(graph.removeEdge(secondNop, thirdNop)); // empty operation
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(secondNop).size());
 
     assertFalse(graph.removeEdge(firstNop, thirdNop)); // empty operation
-    assertEquals(2, graph.getBlocksSorted().size());
+    assertEquals(2, graph.getBlocks().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(secondNop).size());
 
     assertTrue(graph.removeEdge(firstNop, secondNop));
-    assertEquals(3, graph.getBlocksSorted().size());
+    assertEquals(3, graph.getBlocks().size());
   }
 
   @Test
@@ -447,7 +445,7 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(firstNop, secondNop);
     graph.putEdge(secondNop, thirdNop);
     graph.removeNode(firstNop);
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     assertEquals(1, graph.successors(secondNop).size());
     assertEquals(0, graph.successors(thirdNop).size());
     assertEquals(0, graph.predecessors(secondNop).size());
@@ -460,7 +458,7 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(firstNop, secondNop);
     graph.putEdge(secondNop, thirdNop);
     graph.removeNode(secondNop);
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(thirdNop).size());
     assertEquals(0, graph.predecessors(firstNop).size());
@@ -473,7 +471,7 @@ public class MutableBlockStmtGraphTest {
     graph.putEdge(firstNop, secondNop);
     graph.putEdge(secondNop, thirdNop);
     graph.removeNode(thirdNop);
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(secondNop).size());
     assertEquals(0, graph.predecessors(firstNop).size());
@@ -533,7 +531,7 @@ public class MutableBlockStmtGraphTest {
 
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
     graph.putEdge(firstNop, secondNop);
-    assertEquals(1, graph.getBlocksSorted().size());
+    assertEquals(1, graph.getBlocks().size());
     // graph.addTrap(throwableSig, secondNop, secondNop, firstHandlerStmt);
   }
 

--- a/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
@@ -279,6 +279,25 @@ public class MutableBlockStmtGraphTest {
   }
 
   @Test
+  public void removeEdgeMerge() {
+    MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
+
+    graph.addNode(firstNop);
+    graph.setStartingStmt(firstNop);
+    graph.putEdge(firstNop, secondNop);
+    graph.putEdge(secondNop, conditionalStmt);
+
+    assertEquals(1, graph.getBlocks().size());
+    // this edge splits the block between the first and second Nop
+    graph.putEdge(conditionalStmt, secondNop);
+    assertEquals(2, graph.getBlocks().size());
+
+    // this edge removal should merge both blocks together again
+    graph.removeEdge(conditionalStmt, secondNop);
+    assertEquals(1, graph.getBlocks().size());
+  }
+
+  @Test
   public void removeStmtInBetweenBlock() {
 
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();

--- a/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
@@ -175,8 +175,7 @@ public class MutableBlockStmtGraphTest {
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
     graph.setStartingStmt(firstNop);
     graph.setEdges(firstNop, Collections.singletonList(conditionalStmt));
-    assertEquals(
-        Arrays.asList(firstNop, conditionalStmt), graph.getBlockOf(firstNop).getStmts());
+    assertEquals(Arrays.asList(firstNop, conditionalStmt), graph.getBlockOf(firstNop).getStmts());
 
     graph.setEdges(conditionalStmt, Arrays.asList(secondNop, thirdNop));
     assertEquals(3, graph.getBlocks().size());
@@ -203,11 +202,14 @@ public class MutableBlockStmtGraphTest {
 
     graph.removeNode(conditionalStmt, false);
     assertEquals(
-        Collections.singletonList(firstNop).toString(), graph.getBlockOf(firstNop).getStmts().toString());
+        Collections.singletonList(firstNop).toString(),
+        graph.getBlockOf(firstNop).getStmts().toString());
     assertEquals(
-        Collections.singletonList(secondNop).toString(), graph.getBlockOf(secondNop).getStmts().toString());
+        Collections.singletonList(secondNop).toString(),
+        graph.getBlockOf(secondNop).getStmts().toString());
     assertEquals(
-        Collections.singletonList(thirdNop).toString(), graph.getBlockOf(thirdNop).getStmts().toString());
+        Collections.singletonList(thirdNop).toString(),
+        graph.getBlockOf(thirdNop).getStmts().toString());
   }
 
   @Test

--- a/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/MutableBlockStmtGraphTest.java
@@ -256,11 +256,11 @@ public class MutableBlockStmtGraphTest {
     assertEquals(1, graph.getBlocksSorted().get(1).getSuccessors().size());
 
     // remove non-existing edge
-    graph.removeEdge(firstNop, conditionalStmt);
+    assertFalse(graph.removeEdge(firstNop, conditionalStmt));
     assertEquals(2, graph.getBlocksSorted().size());
 
     // remove branchingstmt at end -> edge across blocks
-    graph.removeEdge(conditionalStmt, firstNop);
+    assertTrue(graph.removeEdge(conditionalStmt, firstNop));
     assertEquals(2, graph.getBlocksSorted().size());
 
     assertEquals(4, graph.getNodes().size());
@@ -268,7 +268,7 @@ public class MutableBlockStmtGraphTest {
     assertEquals(3, graph.getNodes().size());
 
     // remove branchingstmt at head
-    graph.removeEdge(conditionalStmt, secondNop);
+    assertTrue(graph.removeEdge(conditionalStmt, secondNop));
     assertEquals(1, graph.getBlocksSorted().size());
     assertEquals(3, graph.getNodes().size());
 
@@ -402,22 +402,22 @@ public class MutableBlockStmtGraphTest {
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(1, graph.successors(secondNop).size());
 
-    graph.removeEdge(secondNop, thirdNop);
+    assertTrue(graph.removeEdge(secondNop, thirdNop));
     assertEquals(2, graph.getBlocksSorted().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(secondNop).size());
 
-    graph.removeEdge(secondNop, thirdNop); // empty operation
+    assertFalse(graph.removeEdge(secondNop, thirdNop)); // empty operation
     assertEquals(2, graph.getBlocksSorted().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(secondNop).size());
 
-    graph.removeEdge(firstNop, thirdNop); // empty operation
+    assertFalse(graph.removeEdge(firstNop, thirdNop)); // empty operation
     assertEquals(2, graph.getBlocksSorted().size());
     assertEquals(1, graph.successors(firstNop).size());
     assertEquals(0, graph.successors(secondNop).size());
 
-    graph.removeEdge(firstNop, secondNop);
+    assertTrue(graph.removeEdge(firstNop, secondNop));
     assertEquals(3, graph.getBlocksSorted().size());
   }
 
@@ -929,7 +929,7 @@ public class MutableBlockStmtGraphTest {
     assertEquals(1, graph.successors(stmt1).size());
     assertTrue(graph.hasEdgeConnecting(stmt1, stmt2));
 
-    graph.removeEdge(stmt1, stmt2);
+    assertTrue(graph.removeEdge(stmt1, stmt2));
     assertEquals(0, graph.successors(stmt1).size());
     assertFalse(graph.hasEdgeConnecting(stmt1, stmt2));
   }
@@ -960,7 +960,7 @@ public class MutableBlockStmtGraphTest {
     Stmt stmt2 = new JNopStmt(StmtPositionInfo.createNoStmtPositionInfo());
     MutableStmtGraph graph = new MutableBlockStmtGraph();
     // nodes are not in the graph!
-    graph.removeEdge(stmt1, stmt2);
+    assertFalse(graph.removeEdge(stmt1, stmt2));
   }
 
   @Test

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/interceptors/DeadAssignmentEliminatorTest.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/interceptors/DeadAssignmentEliminatorTest.java
@@ -19,6 +19,60 @@ import sootup.java.core.types.JavaClassType;
 
 public class DeadAssignmentEliminatorTest {
 
+  /**
+   * <pre>
+   *     void test() {
+   *       if (10 < 20) {
+   *         int a = 42;
+   *       }
+   *       return;
+   *     }
+   * </pre>
+   *
+   * gets simplified to
+   *
+   * <pre>
+   *     void test() {
+   *       if (10 < 20) {
+   *       }
+   *       return;
+   *     }
+   * </pre>
+   *
+   * There used to be a bug that would result in an invalid statement graph because the whole block containing
+   * `int a = 42;` gets deleted.
+   */
+  @Test
+  public void conditionalToRemovedBlock() {
+    StmtPositionInfo noPositionInfo = StmtPositionInfo.createNoStmtPositionInfo();
+
+    Local a = JavaJimple.newLocal("a", PrimitiveType.getInt());
+    Set<Local> locals = ImmutableUtils.immutableSet(a);
+
+    Stmt conditional = JavaJimple.newIfStmt(JavaJimple.newLtExpr(IntConstant.getInstance(10), IntConstant.getInstance(20)), noPositionInfo);
+    Stmt ret = JavaJimple.newReturnVoidStmt(noPositionInfo);
+    Stmt intToA = JavaJimple.newAssignStmt(a, IntConstant.getInstance(42), noPositionInfo);
+
+    Body.BodyBuilder builder = Body.builder();
+    builder.setStartingStmt(conditional);
+    builder.setMethodSignature(
+            JavaIdentifierFactory.getInstance()
+                    .getMethodSignature("test", "ab.c", "void", Collections.emptyList()));
+
+    builder.setLocals(locals);
+    builder.setPosition(NoPositionInformation.getInstance());
+
+    builder.addFlow(conditional, intToA);
+    builder.addFlow(conditional, ret);
+    builder.addFlow(intToA, ret);
+
+    Body beforeBody = builder.build();
+    new DeadAssignmentEliminator().interceptBody(builder, null);
+    Body afterBody = builder.build();
+
+    assertEquals(beforeBody.getStmtGraph().getNodes().size() - 1, afterBody.getStmtGraph().getNodes().size());
+  }
+
   @Test
   public void testRemoveDeadAssignment() {
     Body.BodyBuilder testBuilder = createBody(false);


### PR DESCRIPTION
`removeNode` had multiple issues with `keepFlow = true` (which is the default).
It would remove too many edges and also treated the flow inside a block and the flow between blocks differently.
This also caused the [issue with the `DeadAssignmentEliminator`](https://github.com/soot-oss/SootUp/pull/664#issuecomment-1738674663) that resulted in an invalid statement graph.

Added a test for the issue with the DeadAssignmentEliminator producing an invalid statement graph.

`removeNode` with `keepFlow = true` will now remove the statement and connect all predecessors of the statement with the successor of the statement to maintain the flow. The method will also throw an `IllegalArgumentException` when the statement to be removed has multiple successors (a branching statement), because the semantics of "keeping the flow" are not unambiguous here.

`removeEdge` didn't split blocks correctly and removed too many edges between blocks. This was also fixed. Also removed `removeBlockBorderEdgesInternal`. This implemented somewhat complicated logic that was easier to move inside of `removeEdge`.