### PR TITLE
Allow partial analysis for CallGraphAlgorithm

### DIFF
--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -291,7 +291,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     if (optSc.isPresent()) {
       SootClass<?> sc = optSc.get();
 
-      List<ClassType> superClasses = view.getTypeHierarchy().superClassesOf(sc.getType());
+      List<ClassType> superClasses = view.getTypeHierarchy().incompleteSuperClassesOf(sc.getType());
       Set<ClassType> interfaces = view.getTypeHierarchy().implementedInterfacesOf(sc.getType());
       superClasses.addAll(interfaces);
 
@@ -364,7 +364,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     processWorkList(view, workList, processed, updated);
 
     // Step 2: Add edges from old methods to methods overridden in the new class
-    List<ClassType> superClasses = view.getTypeHierarchy().superClassesOf(classType);
+    List<ClassType> superClasses = view.getTypeHierarchy().incompleteSuperClassesOf(classType);
     Set<ClassType> implementedInterfaces =
         view.getTypeHierarchy().implementedInterfacesOf(classType);
     Stream<ClassType> superTypes =
@@ -376,7 +376,9 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
             .collect(Collectors.toSet());
 
     superTypes
-        .map(view::getClassOrThrow)
+        .map(view::getClass)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
         .flatMap(superType -> superType.getMethods().stream())
         .map(Method::getSignature)
         .filter(

--- a/sootup.core/src/main/java/sootup/core/typehierarchy/TypeHierarchy.java
+++ b/sootup.core/src/main/java/sootup/core/typehierarchy/TypeHierarchy.java
@@ -154,7 +154,7 @@ public interface TypeHierarchy {
         return (supertypeName.equals("java.lang.Object")
                 && !potentialSubtypeName.equals("java.lang.Object"))
             || supertype.equals(superClassOf((ClassType) potentialSubtype))
-            || superClassesOf((ClassType) potentialSubtype).contains(supertype)
+            || incompleteSuperClassesOf((ClassType) potentialSubtype).contains(supertype)
             || implementedInterfacesOf((ClassType) potentialSubtype).contains(supertype);
       } else if (potentialSubtype instanceof ArrayType) {
         // Arrays are subtypes of java.lang.Object, java.io.Serializable and java.lang.Cloneable

--- a/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
@@ -130,11 +130,7 @@ public class JavaView extends AbstractView<JavaSootClass> {
 
     Optional<? extends AbstractClassSource<? extends JavaSootClass>> abstractClass =
         getAbstractClass(type);
-    if (!abstractClass.isPresent()) {
-      return Optional.empty();
-    }
-
-    return buildClassFrom(abstractClass.get());
+    return abstractClass.flatMap(this::buildClassFrom);
   }
 
   /** Returns the amount of classes that are currently stored in the cache. */


### PR DESCRIPTION
https://github.com/soot-oss/SootUp/discussions/710
This PR cleans up usage of `superClassesOf` and `getClassOrThrow`.

Tested with

```
  public static void main(String[] args) {

    AnalysisInputLocation<JavaSootClass> inputLocation = PathBasedAnalysisInputLocation.create(
            Paths.get("hutool-db-5.7.18.jar"), SourceType.Application);

    JavaLanguage language = new JavaLanguage(8);

    JavaProject project = JavaProject.builder(language).addInputLocation(inputLocation).build();
    JavaView view = project.createView();
    AbstractCallGraphAlgorithm cha = new ClassHierarchyAnalysisAlgorithm(view);
    Stream<MethodSignature> methods = view.getClasses()
            .stream()
            .flatMap(c -> c.getMethods().stream())
            .map(SootClassMember::getSignature);
    CallGraph graph = cha.initialize(methods.collect(Collectors.toList()));
    System.out.println(graph);
  }

```