### PR TITLE
Fix two issues with DominanceFinder

### DIFF
--- a/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
+++ b/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
@@ -30,7 +30,8 @@ import javax.annotation.Nonnull;
 /**
  * @author Zun Wang
  * @see <a
- *     href="https://www.cs.rice.edu/~keith/EMBED/dom.pdf">https://www.cs.rice.edu/~keith/EMBED/dom.pdf</a>
+ *     href="https://www.researchgate.net/publication/2569680_A_Simple_Fast_Dominance_Algorithm">
+ *     https://www.researchgate.net/publication/2569680_A_Simple_Fast_Dominance_Algorithm </a>
  */
 public class DominanceFinder {
 

--- a/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
+++ b/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
@@ -45,7 +45,7 @@ public class DominanceFinder {
     {
       int i = 1;
       for (BasicBlock<?> block : blocks) {
-        if (startingStmtBlock == block) {
+        if (startingStmtBlock.equals(block)) {
           blockToIdx.put(block, 0);
         } else {
           blockToIdx.put(block, i);
@@ -66,7 +66,7 @@ public class DominanceFinder {
     while (isChanged) {
       isChanged = false;
       for (BasicBlock<?> block : blocks) {
-        if (block == startingStmtBlock) {
+        if (block.equals(startingStmtBlock)) {
           continue;
         }
         int blockIdx = blockToIdx.get(block);

--- a/sootup.core/src/test/java/sootup/core/graph/DominanceFinderTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/DominanceFinderTest.java
@@ -1,0 +1,141 @@
+package sootup.core.graph;
+
+import static org.junit.Assert.*;
+
+import categories.Java8Test;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import sootup.core.jimple.basic.Local;
+import sootup.core.jimple.basic.StmtPositionInfo;
+import sootup.core.jimple.common.constant.IntConstant;
+import sootup.core.jimple.common.expr.JAddExpr;
+import sootup.core.jimple.common.expr.JLeExpr;
+import sootup.core.jimple.common.stmt.*;
+import sootup.core.types.PrimitiveType;
+
+@Category(Java8Test.class)
+public class DominanceFinderTest {
+
+  StmtPositionInfo noPosInfo = StmtPositionInfo.createNoStmtPositionInfo();
+
+  @Test
+  public void testDominanceFinder() {
+    MutableBlockStmtGraph graph = createStmtGraph();
+    Map<BasicBlock<?>, Integer> blockToId = new HashMap<>();
+    // assign ids according to getBlocksSorted order
+    int i = 0;
+    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+      blockToId.put(block, i);
+      i++;
+    }
+
+    DominanceFinder dom = new DominanceFinder(graph);
+
+    Map<Integer, Set<Integer>> expectedFrontiers = new HashMap<>();
+    expectedFrontiers.put(0, new HashSet<>());
+    expectedFrontiers.put(1, new HashSet<>(Collections.singletonList(1)));
+    expectedFrontiers.put(2, new HashSet<>());
+    expectedFrontiers.put(3, new HashSet<>(Collections.singletonList(1)));
+    expectedFrontiers.put(4, new HashSet<>(Collections.singletonList(6)));
+    expectedFrontiers.put(5, new HashSet<>(Collections.singletonList(6)));
+    expectedFrontiers.put(6, new HashSet<>(Collections.singletonList(1)));
+
+    Map<Integer, Integer> expectedDominators = new HashMap<>();
+    expectedDominators.put(0, 0);
+    expectedDominators.put(1, 0);
+    expectedDominators.put(2, 1);
+    expectedDominators.put(3, 1);
+    expectedDominators.put(4, 3);
+    expectedDominators.put(5, 3);
+    expectedDominators.put(6, 3);
+
+    // check dominators
+    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+      BasicBlock<?> dominator = dom.getImmediateDominator(block);
+      Integer dominatorId = blockToId.get(dominator);
+      Integer expectedId = expectedDominators.get(blockToId.get(block));
+
+      assertEquals(expectedId, dominatorId);
+    }
+
+    // check frontiers
+    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+      Set<BasicBlock<?>> frontier = dom.getDominanceFrontiers(block);
+      Set<Integer> frontierIds = frontier.stream().map(blockToId::get).collect(Collectors.toSet());
+      Set<Integer> expectedIds = expectedFrontiers.get(blockToId.get(block));
+
+      assertEquals(expectedIds, frontierIds);
+    }
+  }
+
+  @Test
+  public void testBlockToIdxInverse() {
+    MutableBlockStmtGraph graph = createStmtGraph();
+    DominanceFinder dom = new DominanceFinder(graph);
+
+    // check that getBlockToIdx and getIdxToBlock are inverses
+    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+      List<BasicBlock<?>> idxToBlock = dom.getIdxToBlock();
+      Map<BasicBlock<?>, Integer> blockToIdx = dom.getBlockToIdx();
+      assertEquals(block, idxToBlock.get(blockToIdx.get(block)));
+    }
+  }
+
+  private MutableBlockStmtGraph createStmtGraph() {
+    // reconstruct the example given in
+    // https://soot-oss.github.io/SootUp/v1.1.2/advanced-topics/#dominancefinder.
+    MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
+
+    Local l1 = new Local("l1", PrimitiveType.IntType.getInstance());
+    Local l2 = new Local("l2", PrimitiveType.IntType.getInstance());
+    Local l3 = new Local("l3", PrimitiveType.IntType.getInstance());
+
+    JAssignStmt assign01 = new JAssignStmt(l1, IntConstant.getInstance(1), noPosInfo);
+    JAssignStmt assign02 = new JAssignStmt(l2, IntConstant.getInstance(2), noPosInfo);
+    JAssignStmt assign03 = new JAssignStmt(l2, IntConstant.getInstance(0), noPosInfo);
+    JAssignStmt assign41 = new JAssignStmt(l2, l3, noPosInfo);
+    JAssignStmt assign42 =
+        new JAssignStmt(l3, new JAddExpr(l3, IntConstant.getInstance(2)), noPosInfo);
+    JAssignStmt assign51 = new JAssignStmt(l2, l1, noPosInfo);
+    JAssignStmt assign52 =
+        new JAssignStmt(l3, new JAddExpr(l3, IntConstant.getInstance(1)), noPosInfo);
+
+    BranchingStmt if1 = new JIfStmt(new JLeExpr(l3, IntConstant.getInstance(100)), noPosInfo);
+    BranchingStmt if3 = new JIfStmt(new JLeExpr(l2, IntConstant.getInstance(20)), noPosInfo);
+
+    JReturnStmt return2 = new JReturnStmt(l2, noPosInfo);
+    JGotoStmt goto4 = new JGotoStmt(noPosInfo);
+    JGotoStmt goto5 = new JGotoStmt(noPosInfo);
+    JGotoStmt goto6 = new JGotoStmt(noPosInfo);
+
+    // block 0
+    graph.setStartingStmt(assign01);
+    graph.putEdge(assign01, assign02);
+    graph.putEdge(assign02, assign03);
+    graph.putEdge(assign03, if1);
+
+    // block 1
+    graph.putEdge(if1, JIfStmt.FALSE_BRANCH_IDX, return2);
+    graph.putEdge(if1, JIfStmt.TRUE_BRANCH_IDX, if3);
+
+    // block 3
+    graph.putEdge(if3, JIfStmt.FALSE_BRANCH_IDX, assign41);
+    graph.putEdge(if3, JIfStmt.TRUE_BRANCH_IDX, assign51);
+
+    // block 4
+    graph.putEdge(assign41, assign42);
+    graph.putEdge(assign42, goto4);
+    graph.putEdge(goto4, JGotoStmt.BRANCH_IDX, goto6);
+
+    // block 5
+    graph.putEdge(assign51, assign52);
+    graph.putEdge(assign52, goto5);
+    graph.putEdge(goto5, JGotoStmt.BRANCH_IDX, goto6);
+
+    // block 6
+    graph.putEdge(goto6, JGotoStmt.BRANCH_IDX, if1);
+    return graph;
+  }
+}


### PR DESCRIPTION
First off: apologies for bundling two fixes with this PR. I would have submitted them separately, but the test I added runs into both issues, and so would fail on any PR which included only a fix for one. I've done the next best thing and split the fixes into commits (c07888eea3ca1f6e3e2a5b50b0fe5b0f2235f43d and b5058575ac1657375370362ef724cf6e7e0653fc). However, I'm happy to split these into PRs on request.

### c07888eea3ca1f6e3e2a5b50b0fe5b0f2235f43d: use .equals to compare to starting stmt

This closes https://github.com/soot-oss/SootUp/issues/586 by using `.equals` for comparison instead of `==`.

### b5058575ac1657375370362ef724cf6e7e0653fc: use correct reverse postorder iteration for dominance finder

While investigating https://github.com/soot-oss/SootUp/issues/586, I found that `DominanceFinder` was not computing the correct dominators for the test I added. I think the reasons for this are two-fold:

* To start, on master, `DominanceFinder#getIdxToBlock` and `DominanceFinder#getBlockToIdx` are *not* inverses (`git checkout c07888eea` and running `testBlockToIdxInverse` confirms this).  This causes dominance indexes to become mixed up internally and the wrong dominator to be returned.
* Even if this is fixed in a simple way, I don't believe that iterating over `blockGraph.getBlocks()` to compute immediate dominators is correct. The [algorithm referenced](https://www.cs.tufts.edu/comp/150FP/archive/keith-cooper/dom14.pdf) requires that blocks are iterated over in reverse postorder. `blockGraph.getBlocks()`'s xmldoc indicates that its ordering is not only not reverse postorder, but is not necessarily in any deterministic order.

I've chosen to iterate over `blockGraph.getBlockIterator()` instead, which fixes the first issue by using `blockGraph.getBlockIterator()` as the ordered source of truth for nodes (and building the backwards `blockToIdx` map straight from it). This also fixes the second issue, as `blockGraph.getBlockIterator()` seems to provide the nodes in reverse postorder, as required. However, I'm not sure if this is an invariant I can rely on - let me know if it's not.

I also fixed a dead pdf link along the way.