### PR TITLE
remove internal dependencyManagement

### DIFF
--- a/sootup.analysis/pom.xml
+++ b/sootup.analysis/pom.xml
@@ -12,19 +12,6 @@
         <version>1.1.2-SNAPSHOT</version>
     </parent>
 
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.soot-oss</groupId>
-                <artifactId>sootup.java.sourcecode</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.soot-oss</groupId>

--- a/sootup.callgraph/pom.xml
+++ b/sootup.callgraph/pom.xml
@@ -12,18 +12,6 @@
 		<version>1.1.2-SNAPSHOT</version>
 	</parent>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.soot-oss</groupId>
-				<artifactId>sootup.java.sourcecode</artifactId>
-				<version>1.1.2-SNAPSHOT</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.soot-oss</groupId>

--- a/sootup.examples/pom.xml
+++ b/sootup.examples/pom.xml
@@ -44,18 +44,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.soot-oss</groupId>
-                <artifactId>sootup.java.sourcecode</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/sootup.jimple.parser/pom.xml
+++ b/sootup.jimple.parser/pom.xml
@@ -72,16 +72,4 @@
         </dependency>
 
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.soot-oss</groupId>
-                <artifactId>sootup.java.sourcecode</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/sootup.report/pom.xml
+++ b/sootup.report/pom.xml
@@ -96,18 +96,4 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.soot-oss</groupId>
-                <artifactId>sootup.java.sourcecode</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-
 </project>

--- a/sootup.tests/pom.xml
+++ b/sootup.tests/pom.xml
@@ -41,18 +41,6 @@
 		</dependency>
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.soot-oss</groupId>
-				<artifactId>sootup.java.sourcecode</artifactId>
-				<version>${project.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
This allows SootUp to be used through jitpack.io with gradle

I'm not sure why these were added in the first place.