### PR TITLE
Migrate dex2jar to Maven Central

### DIFF
--- a/sootup.java.bytecode/pom.xml
+++ b/sootup.java.bytecode/pom.xml
@@ -34,17 +34,13 @@
 			<version>9.5</version>
 		</dependency>
 		<dependency>
-			<groupId>com.github.ThexXTURBOXx.dex2jar</groupId>
-			<artifactId>dex-tools</artifactId>
-			<version>v64</version>
+			<groupId>de.femtopedia.dex2jar</groupId>
+			<artifactId>dex2jar</artifactId>
+			<version>2.4.6</version>
 		</dependency>
 	</dependencies>
 
 	<repositories>
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
 		<repository>
 			<id>maven.google</id>
 			<url>https://maven.google.com/</url>


### PR DESCRIPTION
This should resolve issues with jitpack.io by making it pretty much obsolete.
Releases are done automatically - the patch version is increased automatically and corresponds to the build number in dex2jar's pipeline.

If you need anything else, feel free to contact or ping me or just open an issue at my repository!

Fixes #669