### PR TITLE
Fix CallGraphAlgorithm.addClass(..) implementation

### DIFF
--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -319,7 +319,6 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     Set<MethodSignature> newMethodSignatures =
         clazz.getMethods().stream().map(Method::getSignature).collect(Collectors.toSet());
 
-
     if (newMethodSignatures.stream().anyMatch(oldCallGraph::containsMethod)) {
       // FIXME: [ms] handle better - remove from entry point signatures in this case
       throw new IllegalArgumentException("CallGraph already contains methods from " + classType);
@@ -356,7 +355,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
               MethodSignature overridingMethodSig =
                   clazz.getMethod(overriddenMethodSig.getSubSignature()).get().getSignature();
 
-              if( updated.containsMethod(overriddenMethodSig) ){
+              if (updated.containsMethod(overriddenMethodSig)) {
                 for (MethodSignature callingMethodSig : updated.callsTo(overriddenMethodSig)) {
                   updated.addCall(callingMethodSig, overridingMethodSig);
                 }

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -319,7 +319,9 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     Set<MethodSignature> newMethodSignatures =
         clazz.getMethods().stream().map(Method::getSignature).collect(Collectors.toSet());
 
+
     if (newMethodSignatures.stream().anyMatch(oldCallGraph::containsMethod)) {
+      // FIXME: [ms] handle better - remove from entry point signatures in this case
       throw new IllegalArgumentException("CallGraph already contains methods from " + classType);
     }
 
@@ -354,8 +356,10 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
               MethodSignature overridingMethodSig =
                   clazz.getMethod(overriddenMethodSig.getSubSignature()).get().getSignature();
 
-              for (MethodSignature callingMethodSig : updated.callsTo(overriddenMethodSig)) {
-                updated.addCall(callingMethodSig, overridingMethodSig);
+              if( updated.containsMethod(overriddenMethodSig) ){
+                for (MethodSignature callingMethodSig : updated.callsTo(overriddenMethodSig)) {
+                  updated.addCall(callingMethodSig, overridingMethodSig);
+                }
               }
             });
 

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -313,16 +313,20 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   @Nonnull
   @Override
   public CallGraph addClass(@Nonnull CallGraph oldCallGraph, @Nonnull JavaClassType classType) {
-    MutableCallGraph updated = oldCallGraph.copy();
-
     SootClass<?> clazz = view.getClassOrThrow(classType);
     Set<MethodSignature> newMethodSignatures =
-        clazz.getMethods().stream().map(Method::getSignature).collect(Collectors.toSet());
+        clazz.getMethods().stream()
+            .map(Method::getSignature)
+            .filter(methodSig -> !oldCallGraph.containsMethod(methodSig))
+            .collect(Collectors.toSet());
 
-    if (newMethodSignatures.stream().anyMatch(oldCallGraph::containsMethod)) {
-      // FIXME: [ms] handle better - remove from entry point signatures in this case
-      throw new IllegalArgumentException("CallGraph already contains methods from " + classType);
+    // were all the added method signatures already visited in the CallGraph? i.e. is there
+    // something to add?
+    if (newMethodSignatures.isEmpty()) {
+      return oldCallGraph;
     }
+
+    MutableCallGraph updated = oldCallGraph.copy();
 
     // Step 1: Add edges from the new methods to other methods
     Deque<MethodSignature> workList = new ArrayDeque<>(newMethodSignatures);

--- a/sootup.java.core/src/main/java/sootup/java/core/JavaSootClass.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/JavaSootClass.java
@@ -37,12 +37,19 @@ import sootup.core.signatures.FieldSubSignature;
 import sootup.core.signatures.MethodSubSignature;
 import sootup.core.types.ClassType;
 import sootup.core.types.Type;
+import sootup.java.core.types.JavaClassType;
 import sootup.java.core.views.JavaView;
 
 public class JavaSootClass extends SootClass<JavaSootClassSource> {
 
   public JavaSootClass(JavaSootClassSource classSource, SourceType sourceType) {
     super(classSource, sourceType);
+  }
+
+  @Nonnull
+  @Override
+  public JavaClassType getType() {
+    return (JavaClassType) super.getType();
   }
 
   /**


### PR DESCRIPTION
- [x] in case of non-existing methods in the CG it threw:

```
Exception in thread "main" java.lang.NullPointerException: Node for <org.apache.poi.ss.formula.functions.FreeRefFunction: org.apache.poi.ss.formula.eval.ValueEval evaluate(org.apache.poi.ss.formula.eval.ValueEval[],org.apache.poi.ss.formula.OperationEvaluationContext)> has not been added yet
```

- [x] don't fail if nothing new was added (or a subtask was already calculated before)
- [x] return more convenient Signature from JavaSootClass.getType()