### PR TITLE
Adds repository declaration to installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,17 @@ Take a look at the [Modules](whatsnew.md#modular-architecture) to learn more abo
  Add the following dependency in the ```pom.xml``` file of your project to include all SootUp modules into your project.
  
 ```
+<repositories>
+ <repository>
+  <id>jitpack.io</id>
+  <url>https://jitpack.io</url>
+ </repository>
+ <repository>
+  <id>/maven.google.com</id>
+  <url>https://maven.google.com</url>
+ </repository>
+</repositories>
+
 <dependencies>
  <dependency>
    <groupId>org.soot-oss</groupId>
@@ -57,6 +68,14 @@ Take a look at the [Modules](whatsnew.md#modular-architecture) to learn more abo
 Add the following dependency in the ```build.gradle``` file of your project to include all SootUp modules into your project.
 
 ```
+repositories {
+    mavenCentral()
+    google()
+    maven {
+        url "https://jitpack.io"
+    }
+}
+
 compile "org.soot-oss:sootup.core:{{ git_latest_release }}"
 compile "org.soot-oss:sootup.java.core{{ git_latest_release }}"
 compile "org.soot-oss:sootup.java.sourcecode{{ git_latest_release }}"


### PR DESCRIPTION
Hi,

if one follows the installation procedere described on https://soot-oss.github.io/SootUp/v1.1.2/installation/ with a plain and default Maven installation (no custom artifactory / repository via settings.xml, etc.), several dependencies cannot be retrieved resulting in a build failure.

I suggest to add the required declarations to the documentation, so people have a chance to just consume **or** configure there local artifactory/repo proxies accordingly.