### PR TITLE
fix filesystem caching issues

### DIFF
--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/ArchiveBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/ArchiveBasedAnalysisInputLocation.java
@@ -86,28 +86,26 @@ public class ArchiveBasedAnalysisInputLocation extends PathBasedAnalysisInputLoc
   @Override
   @Nonnull
   public Optional<JavaSootClassSource> getClassSource(@Nonnull ClassType type, @Nonnull View view) {
-    try (FileSystem fs = fileSystemCache.get(path)){
+      try{
+      FileSystem fs = fileSystemCache.get(path);
       final Path archiveRoot = fs.getPath("/");
       return getClassSourceInternal(
           (JavaClassType) type, archiveRoot, new AsmJavaClassProvider(view));
     } catch (ExecutionException e) {
       throw new RuntimeException("Failed to retrieve file system from cache for " + path, e);
-    } catch (IOException e) {
-        throw new RuntimeException(e);
     }
   }
 
   @Override
   @Nonnull
   public Collection<JavaSootClassSource> getClassSources(@Nonnull View view) {
-    try (FileSystem fs = fileSystemCache.get(path)) {
+    try{
+        FileSystem fs = fileSystemCache.get(path);
       final Path archiveRoot = fs.getPath("/");
       return walkDirectory(
           archiveRoot, view.getIdentifierFactory(), new AsmJavaClassProvider(view));
     } catch (ExecutionException e) {
       throw new RuntimeException("Failed to retrieve file system from cache for " + path, e);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
   }
 }

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/ArchiveBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/ArchiveBasedAnalysisInputLocation.java
@@ -32,7 +32,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import sootup.core.model.SourceType;
@@ -50,8 +49,8 @@ public class ArchiveBasedAnalysisInputLocation extends PathBasedAnalysisInputLoc
   // cache can be safely shared in a static variable.
   protected static final LoadingCache<Path, FileSystem> fileSystemCache =
       CacheBuilder.newBuilder()
-              .weakValues()
-              .removalListener(
+          .weakValues()
+          .removalListener(
               (RemovalNotification<Path, FileSystem> removalNotification) -> {
                 try {
                   removalNotification.getValue().close();
@@ -86,7 +85,7 @@ public class ArchiveBasedAnalysisInputLocation extends PathBasedAnalysisInputLoc
   @Override
   @Nonnull
   public Optional<JavaSootClassSource> getClassSource(@Nonnull ClassType type, @Nonnull View view) {
-      try{
+    try {
       FileSystem fs = fileSystemCache.get(path);
       final Path archiveRoot = fs.getPath("/");
       return getClassSourceInternal(
@@ -99,8 +98,8 @@ public class ArchiveBasedAnalysisInputLocation extends PathBasedAnalysisInputLoc
   @Override
   @Nonnull
   public Collection<JavaSootClassSource> getClassSources(@Nonnull View view) {
-    try{
-        FileSystem fs = fileSystemCache.get(path);
+    try {
+      FileSystem fs = fileSystemCache.get(path);
       final Path archiveRoot = fs.getPath("/");
       return walkDirectory(
           archiveRoot, view.getIdentifierFactory(), new AsmJavaClassProvider(view));

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/MultiReleaseJarAnalysisInputLocation.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/inputlocation/MultiReleaseJarAnalysisInputLocation.java
@@ -87,12 +87,13 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
 
   /** Discovers all input locations for different java versions in this multi release jar */
   private void discoverInputLocations(@Nullable SourceType srcType) {
-    FileSystem fs = null;
+    FileSystem fs;
     try {
       fs = fileSystemCache.get(path);
     } catch (ExecutionException e) {
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
+
     final Path archiveRoot = fs.getPath("/");
     final String moduleInfoFilename = JavaModuleIdentifierFactory.MODULE_INFO_FILE + ".class";
 


### PR DESCRIPTION
no timing based cache eviction (+ resource closing) of a filesystem anymore.

- [ ] check when/if cache entries are actually evicted - eventually closing the fs resource. 
e.g. Path can reference a Filesystem and therefore keep the filesystem open/ the cache entry alive

fixes #527
fixes #617