### PR TITLE
Adapt Class validators to SootUp

### DIFF
--- a/sootup.core/src/main/java/sootup/core/types/ArrayType.java
+++ b/sootup.core/src/main/java/sootup/core/types/ArrayType.java
@@ -105,4 +105,9 @@ public class ArrayType extends ReferenceType {
   public void accept(@Nonnull TypeVisitor v) {
     v.caseArrayType();
   }
+
+  @Override
+  public boolean isAllowedInFinalCode() {
+    return true;
+  }
 }

--- a/sootup.core/src/main/java/sootup/core/types/PrimitiveType.java
+++ b/sootup.core/src/main/java/sootup/core/types/PrimitiveType.java
@@ -111,6 +111,11 @@ public abstract class PrimitiveType extends Type {
     public void accept(@Nonnull TypeVisitor v) {
       v.caseByteType();
     }
+
+    @Override
+    public boolean isAllowedInFinalCode() {
+      return true;
+    }
   }
 
   public static class ShortType extends PrimitiveType.IntType {

--- a/sootup.core/src/main/java/sootup/core/types/Type.java
+++ b/sootup.core/src/main/java/sootup/core/types/Type.java
@@ -81,4 +81,13 @@ public abstract class Type implements Acceptor<TypeVisitor> {
     }
     return 0;
   }
+
+  /**
+   * Returns <code>true</code> if this type is allowed to appear in final (clean) Jimple code.
+   *
+   * @return
+   */
+  public boolean isAllowedInFinalCode() {
+    return false;
+  }
 }

--- a/sootup.core/src/main/java/sootup/core/types/VoidType.java
+++ b/sootup.core/src/main/java/sootup/core/types/VoidType.java
@@ -47,4 +47,9 @@ public class VoidType extends Type {
   public void accept(@Nonnull TypeVisitor v) {
     v.caseVoidType();
   }
+
+  @Override
+  public boolean isAllowedInFinalCode() {
+    return true;
+  }
 }

--- a/sootup.core/src/main/java/sootup/core/validation/ClassFlagsValidator.java
+++ b/sootup.core/src/main/java/sootup/core/validation/ClassFlagsValidator.java
@@ -34,13 +34,12 @@ public class ClassFlagsValidator implements ClassValidator {
 
   @Override
   public void validate(SootClass sc, List<ValidationException> exceptions) {
-    // TODO: check code from old soot in the comment
-
-    /*
-     * if (sc.isInterface() && sc.isEnum()) { exceptions.add(new ValidationException(sc,
-     * "Class is both an interface and an enum")); } if (sc.isSynchronized()) { exceptions.add(new ValidationException(sc,
-     * "Classes cannot be synchronized")); }
-     */
+    if (sc.isInterface() && sc.isEnum()) {
+      exceptions.add(new ValidationException(sc, "Class is both an interface and an enum"));
+    }
+    if (sc.isSuper()) {
+      exceptions.add(new ValidationException(sc, "Classes cannot be synchronized"));
+    }
   }
 
   @Override

--- a/sootup.core/src/main/java/sootup/core/validation/MethodDeclarationValidator.java
+++ b/sootup.core/src/main/java/sootup/core/validation/MethodDeclarationValidator.java
@@ -23,7 +23,11 @@ package sootup.core.validation;
  */
 
 import java.util.List;
+
 import sootup.core.model.SootClass;
+import sootup.core.model.SootMethod;
+import sootup.core.types.Type;
+import sootup.core.types.VoidType;
 
 /**
  * Validates classes to make sure that all method signatures are valid
@@ -34,14 +38,22 @@ public class MethodDeclarationValidator implements ClassValidator {
 
   @Override
   public void validate(SootClass sc, List<ValidationException> exceptions) {
-    // TODO: check code from old soot in the comment
-
-    /*
-     * if (sc.isConcrete()) { for (SootMethod sm : sc.getMethods()) { for (Type tp : sm.getParameterTypes()) { if (tp ==
-     * null) { exceptions.add(new ValidationException(sm, "Null parameter types are invalid")); } if (tp instanceof VoidType)
-     * { exceptions.add(new ValidationException(sm, "Void parameter types are invalid")); } if (!tp.isAllowedInFinalCode()) {
-     * exceptions.add(new ValidationException(sm, "Parameter type not allowed in final code")); } } } }
-     */
+    if (sc.isConcrete()) {
+      for (SootMethod sm : sc.getMethods()) {
+        for (Type tp : sm.getParameterTypes()) {
+          if (tp == null) {
+            exceptions.add(new ValidationException(sm, "Null parameter types are invalid"));
+          } else {
+            if (tp instanceof VoidType) {
+              exceptions.add(new ValidationException(sm, "Void parameter types are invalid"));
+            }
+            if (!tp.isAllowedInFinalCode()) {
+              exceptions.add(new ValidationException(sm, "Parameter type not allowed in final code"));
+            }
+          }
+        }
+      }
+    }
   }
 
   @Override

--- a/sootup.core/src/main/java/sootup/core/validation/OuterClassValidator.java
+++ b/sootup.core/src/main/java/sootup/core/validation/OuterClassValidator.java
@@ -22,7 +22,10 @@ package sootup.core.validation;
  * #L%
  */
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 import sootup.core.model.SootClass;
 
 /**
@@ -34,14 +37,15 @@ public class OuterClassValidator implements ClassValidator {
 
   @Override
   public void validate(SootClass sc, List<ValidationException> exceptions) {
-
-    // TODO: check code from old soot in the comment
-
-    /*
-     * Set<SootClass> outerClasses = new HashSet<SootClass>(); SootClass curClass = sc; while (curClass != null) { if
-     * (!outerClasses.add(curClass)) { exceptions.add(new ValidationException(curClass, "Circular outer class chain"));
-     * break; } curClass = curClass.hasOuterClass() ? curClass.getOuterClass() : null; }
-     */
+    // TODO: How to obtain SootClass from ClassType? The return type of curClass.getOuterClass() has changed
+//    Set<SootClass> outerClasses = new HashSet<>();
+//    for (SootClass curClass = sc; curClass != null;) {
+//      if (!outerClasses.add(curClass)) {
+//        exceptions.add(new ValidationException(curClass, "Circular outer class chain"));
+//        break;
+//      }
+//      curClass = curClass.hasOuterClass() ? curClass.getOuterClass() : null;
+//    }
   }
 
   @Override

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/typeresolving/types/AugmentIntegerTypes.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/typeresolving/types/AugmentIntegerTypes.java
@@ -62,6 +62,11 @@ public abstract class AugmentIntegerTypes {
     public void accept(@Nonnull TypeVisitor v) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean isAllowedInFinalCode() {
+      return false;
+    }
   }
 
   /** This type is intermediate type and used for determining the ancestor of an integer type */
@@ -81,6 +86,11 @@ public abstract class AugmentIntegerTypes {
     public void accept(@Nonnull TypeVisitor v) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean isAllowedInFinalCode() {
+      return false;
+    }
   }
 
   /** This type is intermediate type and used for determining the ancestor of an integer type */
@@ -99,6 +109,11 @@ public abstract class AugmentIntegerTypes {
     @Override
     public void accept(@Nonnull TypeVisitor v) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAllowedInFinalCode() {
+      return false;
     }
   }
 }

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/typeresolving/types/WeakObjectType.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/typeresolving/types/WeakObjectType.java
@@ -51,4 +51,9 @@ public class WeakObjectType extends JavaClassType {
   public void accept(@Nonnull TypeVisitor v) {
     // todo: weak objects type case
   }
+
+  @Override
+  public boolean isAllowedInFinalCode() {
+    return true;
+  }
 }

--- a/sootup.java.core/src/main/java/sootup/java/core/types/ModuleJavaClassType.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/types/ModuleJavaClassType.java
@@ -37,4 +37,9 @@ public class ModuleJavaClassType extends JavaClassType {
   public ModulePackageName getPackageName() {
     return (ModulePackageName) super.getPackageName();
   }
+
+  @Override
+  public boolean isAllowedInFinalCode() {
+    return true;
+  }
 }


### PR DESCRIPTION
This pull request modifies the `MethodDeclarationValidator` and `ClassFlagsValidator` classes to be compatible with SootUp. 

- The changes include the addition of a `boolean isAllowedInFinalCode()` method to the Type class and its subclasses for `MethodDeclarationValidator`. 
- Additionally, `sc.isSuper()` is now used in `ClassFlagsValidator` instead of `sc.isSynchronized()` due to a method renaming.

However, the adaptation of `OuterClassValidator` remains incomplete. This validator is designed to check for cycles in the outer class chain, but adapting it is challenging because the return type of `SootClass::getOuterClass` has changed from `SootClass` to `ClassType`. I am uncertain about **how to obtain the `SootClass` object from the `ClassType`**.

Note: There are no test cases included in this pull request, as these class validators are not currently utilized in SootUp. They are typically invoked through `PackManager` in Soot, but it appears that SootUp has not yet ported `PackManager`.