### PR TITLE
Use more precise type

### DIFF
--- a/sootup.core/src/main/java/sootup/core/jimple/common/expr/AbstractInvokeExpr.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/common/expr/AbstractInvokeExpr.java
@@ -53,7 +53,7 @@ public abstract class AbstractInvokeExpr implements Expr {
     return this.methodSignature;
   }
 
-  public Value getArg(int index) {
+  public Immediate getArg(int index) {
     return args[index];
   }
 


### PR DESCRIPTION
```@Nonnull private final Immediate[] args; ``` args is already `Immedediate` array.