### PR TITLE
adapt TypeHierarchy API

### DIFF
--- a/sootup.core/src/main/java/sootup/core/typehierarchy/TypeHierarchy.java
+++ b/sootup.core/src/main/java/sootup/core/typehierarchy/TypeHierarchy.java
@@ -96,11 +96,8 @@ public interface TypeHierarchy {
    * <p>This method relies on {@link #implementedInterfacesOf(ClassType)} and {@link
    * #superClassOf(ClassType)}.
    */
-  default boolean isSubtype(@Nonnull Type supertype, @Nonnull Type potentialSubtype) {
-    if (!(supertype instanceof ReferenceType) || !(potentialSubtype instanceof ReferenceType)) {
-      // Subtyping applies to ReferenceTypes only
-      return false;
-    }
+  default boolean isSubtype(
+      @Nonnull ReferenceType supertype, @Nonnull ReferenceType potentialSubtype) {
 
     if (supertype instanceof NullType) {
       // NullType has no subtypes
@@ -119,14 +116,20 @@ public interface TypeHierarchy {
 
       ArrayType superArrayType = (ArrayType) supertype;
       ArrayType potentialSubArrayType = (ArrayType) potentialSubtype;
-      if (superArrayType.getBaseType() instanceof PrimitiveType) {
-        // Arrays of primitives have no subtypes
+      if (!(superArrayType.getBaseType() instanceof ReferenceType)) {
+        // Arrays of primitives have no subtype
+        return false;
+      }
+      if (!(potentialSubArrayType.getBaseType() instanceof ReferenceType)) {
+        // Arrays of primitives have no supertype/subtype
         return false;
       }
 
       assert superArrayType.getBaseType() instanceof ReferenceType;
 
-      if (isSubtype(superArrayType.getBaseType(), potentialSubArrayType.getBaseType())
+      if (isSubtype(
+              (ReferenceType) superArrayType.getBaseType(),
+              (ReferenceType) potentialSubArrayType.getBaseType())
           && potentialSubArrayType.getDimension() == superArrayType.getDimension()) {
         // Arrays are covariant: Object[] x = new String[0];
         return true;

--- a/sootup.tests/src/test/java/sootup/tests/typehierarchy/ViewTypeHierarchyTest.java
+++ b/sootup.tests/src/test/java/sootup/tests/typehierarchy/ViewTypeHierarchyTest.java
@@ -142,16 +142,6 @@ public class ViewTypeHierarchyTest {
   }
 
   @Test
-  public void primitiveTypeSubtyping() {
-    assertFalse(
-        typeHierarchy.isSubtype(PrimitiveType.getInt(), PrimitiveType.getInt()),
-        "Primitive types should not have subtype relations");
-    assertFalse(
-        typeHierarchy.isSubtype(PrimitiveType.getDouble(), PrimitiveType.getInt()),
-        "Primitive types should not have subtype relations");
-  }
-
-  @Test
   public void nullTypeSubtyping() {
     IdentifierFactory factory = view.getIdentifierFactory();
     assertTrue(
@@ -165,12 +155,6 @@ public class ViewTypeHierarchyTest {
             factory.getClassType("JavaClassPathNamespace", "de.upb.sootup.namespaces"),
             NullType.getInstance()),
         "null should be valid value for all reference types");
-    assertFalse(
-        typeHierarchy.isSubtype(PrimitiveType.getInt(), NullType.getInstance()),
-        "null should not be a valid value for primitive types");
-    assertFalse(
-        typeHierarchy.isSubtype(PrimitiveType.getDouble(), NullType.getInstance()),
-        "null should not be a valid value for primitive types");
   }
 
   @Test
@@ -251,7 +235,7 @@ public class ViewTypeHierarchyTest {
             doubleArrayDim1Type)
         .forEach(type -> assertFalse(typeHierarchy.isSubtype(type, type)));
 
-    Set<Pair<Type, Type>> subtypes =
+    Set<Pair<ReferenceType, ReferenceType>> subtypes =
         ImmutableUtils.immutableSet(
             Pair.of(serializableType, objectArrayDim1Type),
             Pair.of(serializableType, stringType),


### PR DESCRIPTION
isSubType(...) makes only sense with ReferenceTypes; lets keep PrimitiveTypes and ReferenceTypes separate 