### PR TITLE
Reenable previously broken test

### DIFF
--- a/sootup.java.bytecode/pom.xml
+++ b/sootup.java.bytecode/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>de.femtopedia.dex2jar</groupId>
 			<artifactId>dex2jar</artifactId>
-			<version>2.4.6</version>
+			<version>2.4.16</version>
 		</dependency>
     </dependencies>
 

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/Soot1577Test.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/Soot1577Test.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import categories.TestCategories;
 import java.nio.file.Paths;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import sootup.core.inputlocation.AnalysisInputLocation;

--- a/sootup.java.bytecode/src/test/java/sootup/java/bytecode/Soot1577Test.java
+++ b/sootup.java.bytecode/src/test/java/sootup/java/bytecode/Soot1577Test.java
@@ -18,7 +18,6 @@ public class Soot1577Test {
   final String directory = "../shared-test-resources/soot-1577/";
 
   @Test
-  @Disabled("conversion fails - could be a dex2jar conversion problem")
   public void test() {
     AnalysisInputLocation inputLocation =
         new PathBasedAnalysisInputLocation.ClassFileBasedAnalysisInputLocation(


### PR DESCRIPTION
This PR updates dex2jar to the newest version available and reenabled the previously broken Soot-1577 test (related: https://github.com/soot-oss/soot/issues/1577).
After looking a bit into it I found that dex2jar was not the culprit, but rather something fixed in https://github.com/soot-oss/soot/pull/2047/files.
Anyway, I think that https://github.com/soot-oss/soot/issues/1577 can be closed and this PR will enable the appropriate test for the underlying again here.