### PR TITLE
precompute hashCode for JavaClassType and SootClassMemberSignature

### DIFF
--- a/sootup.core/src/main/java/sootup/core/signatures/SootClassMemberSignature.java
+++ b/sootup.core/src/main/java/sootup/core/signatures/SootClassMemberSignature.java
@@ -42,9 +42,12 @@ public abstract class SootClassMemberSignature<V extends SootClassMemberSubSigna
 
   @Nonnull private final V subSignature;
 
+  private final int hashCode;
+
   public SootClassMemberSignature(@Nonnull ClassType klass, @Nonnull V subSignature) {
     this.declClassSignature = klass;
     this.subSignature = subSignature;
+    this.hashCode = Objects.hashCode(declClassSignature, subSignature);
   }
 
   @Nonnull
@@ -84,7 +87,7 @@ public abstract class SootClassMemberSignature<V extends SootClassMemberSubSigna
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(declClassSignature, subSignature);
+    return hashCode;
   }
 
   @Override

--- a/sootup.java.core/src/main/java/sootup/java/core/types/JavaClassType.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/types/JavaClassType.java
@@ -43,6 +43,7 @@ public class JavaClassType extends ClassType {
 
   @Nonnull private final String className;
   @Nonnull private final PackageName packageName;
+  private final int hashCode;
 
   /**
    * Internal: Constructs the fully-qualified ClassSignature. Instances should only be created by a
@@ -59,6 +60,7 @@ public class JavaClassType extends ClassType {
     }
     this.className = realClassName;
     this.packageName = packageName;
+    this.hashCode = Objects.hashCode(className, packageName);
   }
 
   @Override
@@ -75,7 +77,7 @@ public class JavaClassType extends ClassType {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(className, packageName);
+    return hashCode;
   }
 
   /**


### PR DESCRIPTION
This could look weird.
In my use case, I am using `MethodSignature` as key for caches like `Map<MethodSignature, xxx>` and found out that when doing code analysis,  the cache is frequently read and about 15% of time is spent on `hashCode()`.
Since `MethodSignature` and `JavaClassType` are immutable, the hashCode will not change so I cache them in this PR.