### PR TITLE
fix StmtGraph.replaceNode(sameStmt, sameStmt) and Stmt.withNewUse()

### DIFF
--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
@@ -905,6 +905,9 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
 
   @Override
   public void replaceNode(@Nonnull Stmt oldStmt, @Nonnull Stmt newStmt) {
+    if (oldStmt == newStmt) {
+      return;
+    }
 
     final MutableBasicBlock blockOfOldStmt = stmtToBlock.get(oldStmt);
     if (blockOfOldStmt == null) {

--- a/sootup.core/src/main/java/sootup/core/jimple/common/stmt/AbstractStmt.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/common/stmt/AbstractStmt.java
@@ -25,7 +25,6 @@ package sootup.core.jimple.common.stmt;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import sootup.core.jimple.basic.LValue;
 import sootup.core.jimple.basic.StmtPositionInfo;
 import sootup.core.jimple.basic.Value;
@@ -131,17 +130,17 @@ public abstract class AbstractStmt implements Stmt {
    *
    * @param oldUse a Value in the useList of oldStmt.
    * @param newUse a Value is to replace oldUse
-   * @return a new Stmt with newUse or null if oldUse was not found/replaced in the Stmt
+    * @return a new Stmt with newUse or the current Stmt if oldUse was not found/could not be
+   *     replaced in the Stmt
    */
   @Override
-  @Nullable
   public Stmt withNewUse(@Nonnull Value oldUse, @Nonnull Value newUse) {
     ReplaceUseStmtVisitor visitor = new ReplaceUseStmtVisitor(oldUse, newUse);
     try {
       accept(visitor);
     } catch (ClassCastException cce) {
       // new Stmt is not created as the newUse could not be replaced
-      return null;
+      return this;
     }
     return visitor.getResult();
   }

--- a/sootup.core/src/main/java/sootup/core/jimple/common/stmt/AbstractStmt.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/common/stmt/AbstractStmt.java
@@ -130,7 +130,7 @@ public abstract class AbstractStmt implements Stmt {
    *
    * @param oldUse a Value in the useList of oldStmt.
    * @param newUse a Value is to replace oldUse
-    * @return a new Stmt with newUse or the current Stmt if oldUse was not found/could not be
+   * @return a new Stmt with newUse or the current Stmt if oldUse was not found/could not be
    *     replaced in the Stmt
    */
   @Override

--- a/sootup.core/src/main/java/sootup/core/jimple/visitor/ReplaceUseStmtVisitor.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/visitor/ReplaceUseStmtVisitor.java
@@ -85,24 +85,17 @@ public class ReplaceUseStmtVisitor extends AbstractStmtVisitor<Stmt> {
     Value rValue = stmt.getRightOp();
     if (rValue == oldUse) {
       stmt = stmt.withRValue(newUse);
-    } else if (rValue instanceof Immediate) {
-      if (rValue == oldUse) {
-        stmt = stmt.withRValue(newUse);
-      }
     } else if (rValue instanceof Ref) {
-      if (rValue == oldUse) {
-        stmt = stmt.withRValue(newUse);
-      } else {
-        try {
-          refVisitor.init(oldUse, newUse);
-          ((Ref) rValue).accept(refVisitor);
-          if (refVisitor.getResult() != rValue) {
-            stmt = stmt.withRValue(refVisitor.getResult());
-          }
-        } catch (ClassCastException cce) {
-          // can not replace that local by another Value
+      try {
+        refVisitor.init(oldUse, newUse);
+        ((Ref) rValue).accept(refVisitor);
+        if (refVisitor.getResult() != rValue) {
+          stmt = stmt.withRValue(refVisitor.getResult());
         }
+      } catch (ClassCastException cce) {
+        // can not replace that local by another Value
       }
+
     } else if (rValue instanceof Expr) {
       exprVisitor.init(oldUse, newUse);
       ((Expr) rValue).accept(exprVisitor);

--- a/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/CopyPropagator.java
+++ b/sootup.java.bytecode/src/main/java/sootup/java/bytecode/interceptors/CopyPropagator.java
@@ -99,7 +99,7 @@ public class CopyPropagator implements BodyInterceptor {
       @Nonnull MutableStmtGraph graph, @Nonnull Stmt stmt, @Nonnull Value use, @Nonnull Value rhs) {
     if (!use.equivTo(rhs)) { // TODO: ms: check if rhs!=use would be enough
       Stmt newStmt = stmt.withNewUse(use, rhs);
-      if (newStmt != null) {
+      if (newStmt != stmt) {
         graph.replaceNode(stmt, newStmt);
       }
     }


### PR DESCRIPTION
- consistently return the former stmt instead of null
- MutableBlockStmtGraph.replaceNode() failed maintaining index datastructures when replacing a stmt with itself