### PR TITLE
Legacy Jimple Parsing - Transient modifier

### DIFF
--- a/sootup.core/src/main/java/sootup/core/validation/LocalsValidator.java
+++ b/sootup.core/src/main/java/sootup/core/validation/LocalsValidator.java
@@ -56,7 +56,7 @@ public class LocalsValidator implements BodyValidator {
                             + body.getMethodSignature())));
 
     body.getDefs()
-        .parallelStream()
+        .stream()
         .filter(value -> value instanceof Local && !locals.contains(value))
         .forEach(
             value ->

--- a/sootup.core/src/main/java/sootup/core/validation/LocalsValidator.java
+++ b/sootup.core/src/main/java/sootup/core/validation/LocalsValidator.java
@@ -55,8 +55,7 @@ public class LocalsValidator implements BodyValidator {
                             + " in "
                             + body.getMethodSignature())));
 
-    body.getDefs()
-        .stream()
+    body.getDefs().stream()
         .filter(value -> value instanceof Local && !locals.contains(value))
         .forEach(
             value ->

--- a/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
+++ b/sootup.jimple.parser/src/main/antlr4/sootup/jimple/Jimple.g4
@@ -135,7 +135,7 @@ grammar Jimple;
    common_modifier | 'abstract' | 'super';
 
   method_modifier :
-   common_modifier | 'abstract' | 'native' | 'synchronized' | 'varargs'| 'bridge' | 'strictfp';
+   common_modifier | 'abstract' | 'native' | 'synchronized' | 'varargs' | 'bridge' | 'strictfp' | 'transient';
 
   field_modifier :
    common_modifier  | 'transient' | 'volatile';

--- a/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleConverter.java
+++ b/sootup.jimple.parser/src/main/java/sootup/jimple/parser/JimpleConverter.java
@@ -230,7 +230,15 @@ public class JimpleConverter {
     private EnumSet<MethodModifier> getMethodModifiers(
         List<JimpleParser.Method_modifierContext> modifier) {
       return modifier.stream()
-          .map(modContext -> MethodModifier.valueOf(modContext.getText().toUpperCase()))
+          .map(
+              modContext -> {
+                // we need the following check, as old Soot wrongfully mapped VARARGS method
+                // modifiers to TRANSIENT modifiers
+                if (modContext.getText().equalsIgnoreCase("TRANSIENT")) {
+                  return MethodModifier.valueOf("VARARGS");
+                }
+                return MethodModifier.valueOf(modContext.getText().toUpperCase());
+              })
           .collect(Collectors.toCollection(() -> EnumSet.noneOf(MethodModifier.class)));
     }
 

--- a/sootup.jimple.parser/src/test/java/resources/jimple/LegacyTransientMethodModifier.jimple
+++ b/sootup.jimple.parser/src/test/java/resources/jimple/LegacyTransientMethodModifier.jimple
@@ -1,0 +1,7 @@
+class LegacyTransientMethodModifier extends java.lang.Object
+{
+    transient void <init>()
+    {
+        return;
+    }
+}

--- a/sootup.jimple.parser/src/test/java/sootup/jimple/parser/JimpleConverterTest.java
+++ b/sootup.jimple.parser/src/test/java/sootup/jimple/parser/JimpleConverterTest.java
@@ -800,4 +800,18 @@ public class JimpleConverterTest {
       assertEquals(PrimitiveType.DoubleType.getInstance(), field.getType());
     }
   }
+
+  @Test
+  public void testLegacyTransientMethodModifier() throws IOException {
+    SootClass clazz =
+        parseJimpleClass(
+            CharStreams.fromFileName(
+                "src/test/java/resources/jimple/LegacyTransientMethodModifier.jimple"));
+    Set<? extends SootMethod> methods = clazz.getMethods();
+    SootMethod method = methods.iterator().next();
+    Set<MethodModifier> modifiers = method.getModifiers();
+    assertEquals(1, modifiers.size());
+    MethodModifier modifier = modifiers.iterator().next();
+    assertEquals(MethodModifier.VARARGS, modifier);
+  }
 }


### PR DESCRIPTION
Fix bug where legacy Jimple cannot be parsed due to old Soot wrongfully translating the "varargs" method modifier to "transient".
Likely due to the bit set being the same for both modifiers (https://stackoverflow.com/questions/4936803/why-java-methods-with-varargs-identified-as-transient)