### PR TITLE
Transfrom varargs method modifier back into transient

### DIFF
--- a/sootup.core/src/main/java/sootup/core/util/printer/LegacyJimplePrinter.java
+++ b/sootup.core/src/main/java/sootup/core/util/printer/LegacyJimplePrinter.java
@@ -60,4 +60,11 @@ public class LegacyJimplePrinter extends NormalStmtPrinter {
     literal(";");
     newline();
   }
+
+  @Override
+  public void modifier(String modifier) {
+    handleIndent();
+    String legacyModifier = modifier.toLowerCase().replace("varargs", "transient");
+    output.append(legacyModifier);
+  }
 }


### PR DESCRIPTION
Only when printing Jimple in legacy mode for old Soot compatability.