### PR TITLE
Sync antlr-runtime and antlr-maven-plugin versions to get rid of warning

### DIFF
--- a/sootup.jimple.parser/pom.xml
+++ b/sootup.jimple.parser/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.7.2</version>
+            <version>4.9.3</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Cannot update to the newest antlr version, as starting from antlr 4.10, it has to be built using Java 11.