### PR TITLE
update implementation for `BackwardsStmtGraph` and add `PostDominanceFinder` utility

### DIFF
--- a/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
@@ -23,7 +23,6 @@ package sootup.core.graph;
  */
 import java.util.*;
 import javax.annotation.Nonnull;
-import sootup.core.jimple.basic.Trap;
 import sootup.core.jimple.common.stmt.Stmt;
 
 /** @author Zun Wang */
@@ -49,21 +48,16 @@ public class BackwardsStmtGraph extends ForwardingStmtGraph {
     return Collections.unmodifiableCollection(backingGraph.getNodes());
   }
 
-  @Override
-  public boolean containsNode(@Nonnull Stmt node) {
-    return backingGraph.containsNode(node);
-  }
-
   @Nonnull
   @Override
   public List<Stmt> predecessors(@Nonnull Stmt node) {
-    return successors(node);
+    return backingGraph.successors(node);
   }
 
   @Nonnull
   @Override
   public List<Stmt> successors(@Nonnull Stmt node) {
-    return predecessors(node);
+    return backingGraph.predecessors(node);
   }
 
   @Override
@@ -79,11 +73,5 @@ public class BackwardsStmtGraph extends ForwardingStmtGraph {
   @Override
   public boolean hasEdgeConnecting(@Nonnull Stmt source, @Nonnull Stmt target) {
     return backingGraph.hasEdgeConnecting(target, source);
-  }
-
-  @Nonnull
-  @Override
-  public List<Trap> getTraps() {
-    return backingGraph.getTraps();
   }
 }

--- a/sootup.core/src/main/java/sootup/core/graph/PostDominanceFinder.java
+++ b/sootup.core/src/main/java/sootup/core/graph/PostDominanceFinder.java
@@ -1,0 +1,30 @@
+package sootup.core.graph;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997-2021 Zun Wang
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+public class PostDominanceFinder extends DominanceFinder {
+
+  public PostDominanceFinder(StmtGraph<?> blockGraph) {
+    super(blockGraph, AnalysisDirection.BACKWARD);
+  }
+}


### PR DESCRIPTION
update the implementation for `BackwardsStmtGraph` in `sootup.core.graph`

before in `DominanceFinder.java`:
```java
List<BasicBlock<?>> preds = new ArrayList<>(block.getPredecessors());
```

after in `DominanceFinder.java`:
```java
List<BasicBlock<?>> preds = new ArrayList<>(blockGraph.predecessors(block));
```

Apply this change , we can create `PostDominaceFinder` as a wrapper of `DominanceFinder`  directly  through use `backwardStmtGraph` as  internal `backingGraph`. To implement this, I  add `successors`/`predecessors` api  in `StmtGraph` and its subclasses  which use block as param instead of dependending on the `BasicBlock` api:  `getPredecessors`/`getSuccessors`.


```java
public class PostDominanceFinder extends DominanceFinder {

  public PostDominanceFinder(StmtGraph<?> blockGraph) {
    super(new BackwardsStmtGraph(blockGraph));
  }
}
```

Thank you for considering this update!