### PR TITLE
add `ReversePostOrderBlockTraversal` and update `DominanceFinder`

### DIFF
--- a/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
@@ -50,6 +50,14 @@ public class BackwardsStmtGraph extends ForwardingStmtGraph {
 
   @Nonnull
   @Override
+  public List<? extends BasicBlock<?>> getBlocksSorted() {
+    List<? extends BasicBlock<?>> blocksSorted = super.getBlocksSorted();
+    Collections.reverse(blocksSorted);
+    return blocksSorted;
+  }
+
+  @Nonnull
+  @Override
   public List<Stmt> predecessors(@Nonnull Stmt node) {
     return backingGraph.successors(node);
   }

--- a/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
@@ -51,9 +51,7 @@ public class BackwardsStmtGraph extends ForwardingStmtGraph {
   @Nonnull
   @Override
   public List<? extends BasicBlock<?>> getBlocksSorted() {
-    List<? extends BasicBlock<?>> blocksSorted = super.getBlocksSorted();
-    Collections.reverse(blocksSorted);
-    return blocksSorted;
+    return PostOrderBlockTraversal.getBlocksSorted(backingGraph);
   }
 
   @Nonnull

--- a/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
+++ b/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
@@ -38,7 +38,7 @@ public class DominanceFinder {
   private int[] doms;
   private ArrayList<Integer>[] domFrontiers;
 
-  protected AnalysisDirection direction = AnalysisDirection.FORWARD;
+  protected AnalysisDirection direction;
 
   public enum AnalysisDirection {
     BACKWARD {

--- a/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
+++ b/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
@@ -64,7 +64,7 @@ public class DominanceFinder {
       @Nonnull
       @Override
       List<BasicBlock<?>> getSortedBlocks(StmtGraph<?> blockGraph) {
-        return Collections.unmodifiableList(new ForwardingStmtGraph(blockGraph).getBlocksSorted());
+        return Collections.unmodifiableList(blockGraph.getBlocksSorted());
       }
     };
 

--- a/sootup.core/src/main/java/sootup/core/graph/ForwardingStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/ForwardingStmtGraph.java
@@ -20,10 +20,9 @@ package sootup.core.graph;
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import sootup.core.jimple.basic.Trap;
 import sootup.core.jimple.common.stmt.Stmt;
@@ -72,7 +71,12 @@ public class ForwardingStmtGraph<V extends BasicBlock<V>> extends StmtGraph<V> {
   @Nonnull
   @Override
   public List<? extends BasicBlock<?>> getBlocksSorted() {
-    return backingGraph.getBlocksSorted();
+    return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(
+                new ReversePostOrderBlockTraversal.ReversePostOrderBlockIterator(backingGraph),
+                Spliterator.ORDERED),
+            false)
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/sootup.core/src/main/java/sootup/core/graph/ForwardingStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/ForwardingStmtGraph.java
@@ -21,8 +21,6 @@ package sootup.core.graph;
  * #L%
  */
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import sootup.core.jimple.basic.Trap;
 import sootup.core.jimple.common.stmt.Stmt;
@@ -71,12 +69,7 @@ public class ForwardingStmtGraph<V extends BasicBlock<V>> extends StmtGraph<V> {
   @Nonnull
   @Override
   public List<? extends BasicBlock<?>> getBlocksSorted() {
-    return StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(
-                new ReversePostOrderBlockTraversal.ReversePostOrderBlockIterator(backingGraph),
-                Spliterator.ORDERED),
-            false)
-        .collect(Collectors.toList());
+    return ReversePostOrderBlockTraversal.getBlocksSorted(backingGraph);
   }
 
   @Override

--- a/sootup.core/src/main/java/sootup/core/graph/ForwardingStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/ForwardingStmtGraph.java
@@ -69,7 +69,7 @@ public class ForwardingStmtGraph<V extends BasicBlock<V>> extends StmtGraph<V> {
   @Nonnull
   @Override
   public List<? extends BasicBlock<?>> getBlocksSorted() {
-    return ReversePostOrderBlockTraversal.getBlocksSorted(backingGraph);
+    return backingGraph.getBlocksSorted();
   }
 
   @Override

--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockStmtGraph.java
@@ -25,8 +25,6 @@ package sootup.core.graph;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import sootup.core.jimple.Jimple;
@@ -447,9 +445,7 @@ public class MutableBlockStmtGraph extends MutableStmtGraph {
 
   @Nonnull
   public List<? extends BasicBlock<?>> getBlocksSorted() {
-    return StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(getBlockIterator(), Spliterator.ORDERED), false)
-        .collect(Collectors.toList());
+    return ReversePostOrderBlockTraversal.getBlocksSorted(this);
   }
 
   /**

--- a/sootup.core/src/main/java/sootup/core/graph/PostDominanceFinder.java
+++ b/sootup.core/src/main/java/sootup/core/graph/PostDominanceFinder.java
@@ -4,7 +4,7 @@ package sootup.core.graph;
  * #%L
  * Soot - a J*va Optimization Framework
  * %%
- * Copyright (C) 1997-2021 Zun Wang
+ * Copyright (C) 2024 Junjie Shen
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockTraversal.java
+++ b/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockTraversal.java
@@ -1,0 +1,86 @@
+package sootup.core.graph;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nonnull;
+
+public class PostOrderBlockTraversal {
+
+  private final BasicBlock<?> startNode;
+
+  public PostOrderBlockTraversal(StmtGraph<?> cfg) {
+    startNode = cfg.getStartingStmtBlock();
+  }
+
+  public PostOrderBlockTraversal(BasicBlock<?> startNode) {
+    this.startNode = startNode;
+  }
+
+  public Iterable<BasicBlock<?>> getOrder() {
+    return this::iterator;
+  }
+
+  public BlockIterator iterator() {
+    return new BlockIterator(startNode);
+  }
+
+  @Nonnull
+  public static List<BasicBlock<?>> getBlocksSorted(StmtGraph<?> cfg) {
+    return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(
+                new PostOrderBlockTraversal(cfg).iterator(), Spliterator.ORDERED),
+            false)
+        .collect(Collectors.toList());
+  }
+
+  public static class BlockIterator implements Iterator<BasicBlock<?>> {
+    private final Stack<Frame> stack = new Stack<>();
+    private final Set<BasicBlock<?>> visited = new HashSet<>();
+
+    public BlockIterator(@Nonnull BasicBlock<?> startNode) {
+      visitNode(startNode);
+      stack.push(
+          new Frame(startNode, ((List<BasicBlock<?>>) startNode.getSuccessors()).iterator()));
+    }
+
+    private boolean visitNode(@Nonnull BasicBlock<?> node) {
+      return visited.add(node);
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !stack.isEmpty();
+    }
+
+    @Override
+    public BasicBlock<?> next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException("There is no more block.");
+      }
+      while (!stack.isEmpty()) {
+        Frame frame = stack.peek();
+        if (frame.succIterator.hasNext()) {
+          BasicBlock<?> succ = frame.succIterator.next();
+          if (visitNode(succ)) {
+            stack.push(new Frame(succ, ((List<BasicBlock<?>>) succ.getSuccessors()).iterator()));
+          }
+        } else {
+          stack.pop();
+          return frame.node;
+        }
+      }
+      return null;
+    }
+
+    private static class Frame {
+      final BasicBlock<?> node;
+      final Iterator<BasicBlock<?>> succIterator;
+
+      Frame(BasicBlock<?> node, Iterator<BasicBlock<?>> childIterator) {
+        this.node = node;
+        this.succIterator = childIterator;
+      }
+    }
+  }
+}

--- a/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockTraversal.java
+++ b/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockTraversal.java
@@ -1,5 +1,27 @@
 package sootup.core.graph;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2024 Junjie Shen
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;

--- a/sootup.core/src/main/java/sootup/core/graph/ReversePostOrderBlockTraversal.java
+++ b/sootup.core/src/main/java/sootup/core/graph/ReversePostOrderBlockTraversal.java
@@ -1,5 +1,27 @@
 package sootup.core.graph;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2024 Junjie Shen
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;

--- a/sootup.core/src/main/java/sootup/core/graph/ReversePostOrderBlockTraversal.java
+++ b/sootup.core/src/main/java/sootup/core/graph/ReversePostOrderBlockTraversal.java
@@ -1,0 +1,129 @@
+package sootup.core.graph;
+
+import java.util.*;
+
+public class ReversePostOrderBlockTraversal {
+  private final StmtGraph<?> cfg;
+
+  public ReversePostOrderBlockTraversal(StmtGraph<?> cfg) {
+    this.cfg = cfg;
+  }
+
+  public Iterable<BasicBlock<?>> getOrder() {
+    return () -> new ReversePostOrderBlockIterator(cfg);
+  }
+
+  public static class ReversePostOrderBlockIterator implements Iterator<BasicBlock<?>> {
+    StmtGraph<?> cfg;
+    private Set<BasicBlock<?>> visited;
+    Map<BasicBlock<?>, WorkUnit> worklist;
+    boolean tryPop;
+    WorkUnit popResult;
+
+    private static class Frame {
+      final BasicBlock<?> node;
+      final Iterator<BasicBlock<?>> childIterator;
+
+      Frame(BasicBlock<?> node, Iterator<BasicBlock<?>> childIterator) {
+        this.node = node;
+        this.childIterator = childIterator;
+      }
+    }
+
+    public ReversePostOrderBlockIterator(StmtGraph<?> cfg) {
+      this.cfg = cfg;
+      this.visited = new HashSet<>();
+      this.worklist = new HashMap<>();
+      this.tryPop = false;
+
+      initialize();
+    }
+
+    public void initialize() {
+      BasicBlock<?> startNode = cfg.getStartingStmtBlock();
+      if (startNode != null) {
+        worklist.put(startNode, new WorkUnit(startNode));
+      }
+    }
+
+    private void popWithHighestPriority() {
+      tryPop = true;
+      popResult = null;
+      if (worklist.isEmpty()) {
+        return;
+      }
+      Optional<Map.Entry<BasicBlock<?>, WorkUnit>> optEntry =
+          worklist.entrySet().stream()
+              .min(Map.Entry.comparingByValue(Comparator.comparingInt(WorkUnit::getPriority)));
+      if (optEntry.isPresent()) {
+        Map.Entry<BasicBlock<?>, WorkUnit> entry = optEntry.get();
+        worklist.remove(entry.getKey());
+        popResult = entry.getValue();
+      }
+    }
+
+    private void updateWorkListBySuccessors(BasicBlock<?> currentNode) {
+      for (BasicBlock<?> succ : currentNode.getSuccessors()) {
+        if (!visited.contains(succ)) {
+          WorkUnit work = worklist.getOrDefault(succ, new WorkUnit(succ));
+          work.addVisitedPred(currentNode);
+          worklist.put(succ, work);
+        }
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (!tryPop) {
+        popWithHighestPriority();
+      }
+      return popResult != null;
+    }
+
+    @Override
+    public BasicBlock<?> next() {
+      if (!tryPop) {
+        popWithHighestPriority();
+      }
+      if (popResult == null) {
+        throw new NoSuchElementException("There are no more blocks.");
+      }
+
+      tryPop = false;
+      BasicBlock<?> currentNode = popResult.getNode();
+      visited.add(currentNode);
+
+      updateWorkListBySuccessors(currentNode);
+      return currentNode;
+    }
+
+    public static class WorkUnit {
+      private final BasicBlock<?> node;
+      private final Set<BasicBlock<?>> visitedPreds = new HashSet<>();
+      private int priority;
+
+      public WorkUnit(BasicBlock<?> node) {
+        this.node = node;
+        computePriority(node);
+      }
+
+      private void computePriority(BasicBlock<?> node) {
+        int totalPreds = node.getPredecessors().size();
+        this.priority = totalPreds - visitedPreds.size();
+      }
+
+      public void addVisitedPred(BasicBlock<?> node) {
+        this.visitedPreds.add(node);
+        computePriority(node);
+      }
+
+      public BasicBlock<?> getNode() {
+        return node;
+      }
+
+      public int getPriority() {
+        return priority;
+      }
+    }
+  }
+}

--- a/sootup.core/src/test/java/sootup/core/graph/DominanceFinderTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/DominanceFinderTest.java
@@ -23,9 +23,13 @@ public class DominanceFinderTest {
   public void testDominanceFinder() {
     MutableBlockStmtGraph graph = createStmtGraph();
     Map<BasicBlock<?>, Integer> blockToId = new HashMap<>();
-    // assign ids according to getBlocksSorted order
+    // assign ids according to blocks sorted by BasicBlock::toString
+    List<? extends BasicBlock<?>> blocks =
+        graph.getBlocks().stream()
+            .sorted(Comparator.comparing(BasicBlock::toString))
+            .collect(Collectors.toList());
     int i = 0;
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+    for (BasicBlock<?> block : blocks) {
       blockToId.put(block, i);
       i++;
     }
@@ -33,25 +37,25 @@ public class DominanceFinderTest {
     DominanceFinder dom = new DominanceFinder(graph);
 
     Map<Integer, Set<Integer>> expectedFrontiers = new HashMap<>();
-    expectedFrontiers.put(0, new HashSet<>());
-    expectedFrontiers.put(1, new HashSet<>(Collections.singletonList(1)));
-    expectedFrontiers.put(2, new HashSet<>());
-    expectedFrontiers.put(3, new HashSet<>(Collections.singletonList(1)));
-    expectedFrontiers.put(4, new HashSet<>(Collections.singletonList(6)));
-    expectedFrontiers.put(5, new HashSet<>(Collections.singletonList(6)));
-    expectedFrontiers.put(6, new HashSet<>(Collections.singletonList(1)));
+    expectedFrontiers.put(0, new HashSet<>(Collections.singletonList(2)));
+    expectedFrontiers.put(1, new HashSet<>(Collections.singletonList(2)));
+    expectedFrontiers.put(2, new HashSet<>(Collections.singletonList(2)));
+    expectedFrontiers.put(3, new HashSet<>());
+    expectedFrontiers.put(4, new HashSet<>(Collections.singletonList(0)));
+    expectedFrontiers.put(5, new HashSet<>(Collections.singletonList(0)));
+    expectedFrontiers.put(6, new HashSet<>());
 
     Map<Integer, Integer> expectedDominators = new HashMap<>();
-    expectedDominators.put(0, -1);
-    expectedDominators.put(1, 0);
-    expectedDominators.put(2, 1);
-    expectedDominators.put(3, 1);
-    expectedDominators.put(4, 3);
-    expectedDominators.put(5, 3);
-    expectedDominators.put(6, 3);
+    expectedDominators.put(0, 1);
+    expectedDominators.put(1, 2);
+    expectedDominators.put(2, 3);
+    expectedDominators.put(3, -1);
+    expectedDominators.put(4, 1);
+    expectedDominators.put(5, 1);
+    expectedDominators.put(6, 2);
 
     // check dominators
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+    for (BasicBlock<?> block : blocks) {
       Integer dominatorId = -1;
       BasicBlock<?> dominator = dom.getImmediateDominator(block);
       if (dominator != null) {
@@ -63,7 +67,7 @@ public class DominanceFinderTest {
     }
 
     // check frontiers
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+    for (BasicBlock<?> block : blocks) {
       Set<BasicBlock<?>> frontier = dom.getDominanceFrontiers(block);
       Set<Integer> frontierIds = frontier.stream().map(blockToId::get).collect(Collectors.toSet());
       Set<Integer> expectedIds = expectedFrontiers.get(blockToId.get(block));
@@ -78,7 +82,7 @@ public class DominanceFinderTest {
     DominanceFinder dom = new DominanceFinder(graph);
 
     // check that getBlockToIdx and getIdxToBlock are inverses
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+    for (BasicBlock<?> block : graph.getBlocks()) {
       List<BasicBlock<?>> idxToBlock = dom.getIdxToBlock();
       Map<BasicBlock<?>, Integer> blockToIdx = dom.getBlockToIdx();
       assertEquals(block, idxToBlock.get(blockToIdx.get(block)));

--- a/sootup.core/src/test/java/sootup/core/graph/PostDominanceFinderTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/PostDominanceFinderTest.java
@@ -51,13 +51,14 @@ public class PostDominanceFinderTest {
     expectedDominators.put(6, 1);
 
     // check dominators
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
+    for (BasicBlock<?> block : graph.getBlocks()) {
       BasicBlock<?> dominator = postDom.getImmediateDominator(block);
       Integer dominatorId = -1;
       if (dominator != null) {
         dominatorId = blockToId.get(dominator);
       }
       Integer expectedId = expectedDominators.get(blockToId.get(block));
+
       assertEquals(expectedId, dominatorId);
     }
 
@@ -74,7 +75,7 @@ public class PostDominanceFinderTest {
   @Test
   public void testBlockToIdxInverse() {
     MutableBlockStmtGraph graph = createStmtGraph();
-    DominanceFinder dom = new DominanceFinder(graph);
+    DominanceFinder dom = new PostDominanceFinder(graph);
 
     // check that getBlockToIdx and getIdxToBlock are inverses
     for (BasicBlock<?> block : graph.getBlocksSorted()) {

--- a/sootup.core/src/test/java/sootup/core/graph/PostDominanceFinderTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/PostDominanceFinderTest.java
@@ -15,7 +15,7 @@ import sootup.core.jimple.common.stmt.*;
 import sootup.core.types.PrimitiveType;
 
 @Tag("Java8")
-public class DominanceFinderTest {
+public class PostDominanceFinderTest {
 
   StmtPositionInfo noPosInfo = StmtPositionInfo.getNoStmtPositionInfo();
 
@@ -30,30 +30,30 @@ public class DominanceFinderTest {
       i++;
     }
 
-    DominanceFinder dom = new DominanceFinder(graph);
+    PostDominanceFinder postDom = new PostDominanceFinder(graph);
 
     Map<Integer, Set<Integer>> expectedFrontiers = new HashMap<>();
     expectedFrontiers.put(0, new HashSet<>());
     expectedFrontiers.put(1, new HashSet<>(Collections.singletonList(1)));
     expectedFrontiers.put(2, new HashSet<>());
     expectedFrontiers.put(3, new HashSet<>(Collections.singletonList(1)));
-    expectedFrontiers.put(4, new HashSet<>(Collections.singletonList(6)));
-    expectedFrontiers.put(5, new HashSet<>(Collections.singletonList(6)));
+    expectedFrontiers.put(4, new HashSet<>(Collections.singletonList(3)));
+    expectedFrontiers.put(5, new HashSet<>(Collections.singletonList(3)));
     expectedFrontiers.put(6, new HashSet<>(Collections.singletonList(1)));
 
     Map<Integer, Integer> expectedDominators = new HashMap<>();
-    expectedDominators.put(0, -1);
-    expectedDominators.put(1, 0);
-    expectedDominators.put(2, 1);
-    expectedDominators.put(3, 1);
-    expectedDominators.put(4, 3);
-    expectedDominators.put(5, 3);
-    expectedDominators.put(6, 3);
+    expectedDominators.put(0, 1);
+    expectedDominators.put(1, 2);
+    expectedDominators.put(2, -1);
+    expectedDominators.put(3, 6);
+    expectedDominators.put(4, 6);
+    expectedDominators.put(5, 6);
+    expectedDominators.put(6, 1);
 
     // check dominators
     for (BasicBlock<?> block : graph.getBlocksSorted()) {
+      BasicBlock<?> dominator = postDom.getImmediateDominator(block);
       Integer dominatorId = -1;
-      BasicBlock<?> dominator = dom.getImmediateDominator(block);
       if (dominator != null) {
         dominatorId = blockToId.get(dominator);
       }
@@ -63,7 +63,7 @@ public class DominanceFinderTest {
 
     // check frontiers
     for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      Set<BasicBlock<?>> frontier = dom.getDominanceFrontiers(block);
+      Set<BasicBlock<?>> frontier = postDom.getDominanceFrontiers(block);
       Set<Integer> frontierIds = frontier.stream().map(blockToId::get).collect(Collectors.toSet());
       Set<Integer> expectedIds = expectedFrontiers.get(blockToId.get(block));
 
@@ -85,8 +85,6 @@ public class DominanceFinderTest {
   }
 
   private MutableBlockStmtGraph createStmtGraph() {
-    // reconstruct the example given in
-    // https://soot-oss.github.io/SootUp/v1.1.2/advanced-topics/#dominancefinder.
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
 
     Local l1 = new Local("l1", PrimitiveType.IntType.getInstance());

--- a/sootup.core/src/test/java/sootup/core/graph/PostOrderTraversalTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/PostOrderTraversalTest.java
@@ -2,8 +2,8 @@ package sootup.core.graph;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import sootup.core.jimple.basic.Local;
@@ -15,79 +15,48 @@ import sootup.core.jimple.common.stmt.*;
 import sootup.core.types.PrimitiveType;
 
 @Tag("Java8")
-public class DominanceFinderTest {
-
+public class PostOrderTraversalTest {
   StmtPositionInfo noPosInfo = StmtPositionInfo.getNoStmtPositionInfo();
 
   @Test
-  public void testDominanceFinder() {
+  void testReversePostorderTraversal() {
     MutableBlockStmtGraph graph = createStmtGraph();
-    Map<BasicBlock<?>, Integer> blockToId = new HashMap<>();
-    // assign ids according to getBlocksSorted order
+    Map<BasicBlock<?>, Integer> blockToSortedId = new HashMap<>();
+    Map<BasicBlock<?>, Integer> blockToPOId = new HashMap<>();
+    // assign sorted ids according to MutableBlockStmtGraph.getBlocksSorted
     int i = 0;
     for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      blockToId.put(block, i);
+      blockToSortedId.put(block, i);
       i++;
     }
 
-    DominanceFinder dom = new DominanceFinder(graph);
-
-    Map<Integer, Set<Integer>> expectedFrontiers = new HashMap<>();
-    expectedFrontiers.put(0, new HashSet<>());
-    expectedFrontiers.put(1, new HashSet<>(Collections.singletonList(1)));
-    expectedFrontiers.put(2, new HashSet<>());
-    expectedFrontiers.put(3, new HashSet<>(Collections.singletonList(1)));
-    expectedFrontiers.put(4, new HashSet<>(Collections.singletonList(6)));
-    expectedFrontiers.put(5, new HashSet<>(Collections.singletonList(6)));
-    expectedFrontiers.put(6, new HashSet<>(Collections.singletonList(1)));
-
-    Map<Integer, Integer> expectedDominators = new HashMap<>();
-    expectedDominators.put(0, -1);
-    expectedDominators.put(1, 0);
-    expectedDominators.put(2, 1);
-    expectedDominators.put(3, 1);
-    expectedDominators.put(4, 3);
-    expectedDominators.put(5, 3);
-    expectedDominators.put(6, 3);
-
-    // check dominators
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      Integer dominatorId = -1;
-      BasicBlock<?> dominator = dom.getImmediateDominator(block);
-      if (dominator != null) {
-        dominatorId = blockToId.get(dominator);
-      }
-      Integer expectedId = expectedDominators.get(blockToId.get(block));
-
-      assertEquals(expectedId, dominatorId);
+    // assign po ids according to ReversePostOrderBlockTraversal.getOrder
+    Iterable<BasicBlock<?>> RPO = new PostOrderBlockTraversal(graph).getOrder();
+    i = 0;
+    for (BasicBlock<?> block : RPO) {
+      blockToPOId.put(block, i);
+      i++;
     }
 
-    // check frontiers
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      Set<BasicBlock<?>> frontier = dom.getDominanceFrontiers(block);
-      Set<Integer> frontierIds = frontier.stream().map(blockToId::get).collect(Collectors.toSet());
-      Set<Integer> expectedIds = expectedFrontiers.get(blockToId.get(block));
+    Map<Integer, Integer> expectedSortedIdToRPOId = new HashMap<>();
+    expectedSortedIdToRPOId.put(0, 6);
+    expectedSortedIdToRPOId.put(1, 5);
+    expectedSortedIdToRPOId.put(2, 0);
+    expectedSortedIdToRPOId.put(3, 4);
+    expectedSortedIdToRPOId.put(4, 2);
+    expectedSortedIdToRPOId.put(5, 3);
+    expectedSortedIdToRPOId.put(6, 1);
 
-      assertEquals(expectedIds, frontierIds);
-    }
-  }
+    for (BasicBlock<?> block : RPO) {
+      Integer sortedId = blockToSortedId.get(block);
+      Integer rpoId = blockToPOId.get(block);
+      Integer expectedRPOId = expectedSortedIdToRPOId.get(sortedId);
 
-  @Test
-  public void testBlockToIdxInverse() {
-    MutableBlockStmtGraph graph = createStmtGraph();
-    DominanceFinder dom = new DominanceFinder(graph);
-
-    // check that getBlockToIdx and getIdxToBlock are inverses
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      List<BasicBlock<?>> idxToBlock = dom.getIdxToBlock();
-      Map<BasicBlock<?>, Integer> blockToIdx = dom.getBlockToIdx();
-      assertEquals(block, idxToBlock.get(blockToIdx.get(block)));
+      assertEquals(expectedRPOId, rpoId);
     }
   }
 
   private MutableBlockStmtGraph createStmtGraph() {
-    // reconstruct the example given in
-    // https://soot-oss.github.io/SootUp/v1.1.2/advanced-topics/#dominancefinder.
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
 
     Local l1 = new Local("l1", PrimitiveType.IntType.getInstance());

--- a/sootup.core/src/test/java/sootup/core/graph/PostOrderTraversalTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/PostOrderTraversalTest.java
@@ -2,8 +2,11 @@ package sootup.core.graph;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import sootup.core.jimple.basic.Local;
@@ -21,38 +24,42 @@ public class PostOrderTraversalTest {
   @Test
   void testReversePostorderTraversal() {
     MutableBlockStmtGraph graph = createStmtGraph();
-    Map<BasicBlock<?>, Integer> blockToSortedId = new HashMap<>();
+    Map<BasicBlock<?>, Integer> blocksToId = new HashMap<>();
     Map<BasicBlock<?>, Integer> blockToPOId = new HashMap<>();
-    // assign sorted ids according to MutableBlockStmtGraph.getBlocksSorted
+    // assign ids according to blocks sorted by BasicBlock::toString
+    List<? extends BasicBlock<?>> blocks =
+        graph.getBlocks().stream()
+            .sorted(Comparator.comparing(BasicBlock::toString))
+            .collect(Collectors.toList());
     int i = 0;
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      blockToSortedId.put(block, i);
+    for (BasicBlock<?> block : blocks) {
+      blocksToId.put(block, i);
       i++;
     }
 
-    // assign po ids according to ReversePostOrderBlockTraversal.getOrder
-    Iterable<BasicBlock<?>> RPO = new PostOrderBlockTraversal(graph).getOrder();
+    // assign po ids according to PostOrderBlockTraversal.getOrder
+    Iterable<BasicBlock<?>> PO = new PostOrderBlockTraversal(graph).getOrder();
     i = 0;
-    for (BasicBlock<?> block : RPO) {
+    for (BasicBlock<?> block : PO) {
       blockToPOId.put(block, i);
       i++;
     }
 
     Map<Integer, Integer> expectedSortedIdToRPOId = new HashMap<>();
-    expectedSortedIdToRPOId.put(0, 6);
-    expectedSortedIdToRPOId.put(1, 5);
-    expectedSortedIdToRPOId.put(2, 0);
-    expectedSortedIdToRPOId.put(3, 4);
-    expectedSortedIdToRPOId.put(4, 2);
-    expectedSortedIdToRPOId.put(5, 3);
-    expectedSortedIdToRPOId.put(6, 1);
+    expectedSortedIdToRPOId.put(0, 1);
+    expectedSortedIdToRPOId.put(1, 4);
+    expectedSortedIdToRPOId.put(2, 5);
+    expectedSortedIdToRPOId.put(3, 6);
+    expectedSortedIdToRPOId.put(4, 3);
+    expectedSortedIdToRPOId.put(5, 2);
+    expectedSortedIdToRPOId.put(6, 0);
 
-    for (BasicBlock<?> block : RPO) {
-      Integer sortedId = blockToSortedId.get(block);
-      Integer rpoId = blockToPOId.get(block);
-      Integer expectedRPOId = expectedSortedIdToRPOId.get(sortedId);
+    for (BasicBlock<?> block : PO) {
+      Integer id = blocksToId.get(block);
+      Integer poId = blockToPOId.get(block);
+      Integer expectedPOId = expectedSortedIdToRPOId.get(id);
 
-      assertEquals(expectedRPOId, rpoId);
+      assertEquals(expectedPOId, poId);
     }
   }
 

--- a/sootup.core/src/test/java/sootup/core/graph/ReversePostOrderTraversalTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/ReversePostOrderTraversalTest.java
@@ -42,14 +42,15 @@ public class ReversePostOrderTraversalTest {
     expectedSortedIdToRPOId.put(1, 1);
     expectedSortedIdToRPOId.put(2, 6);
     expectedSortedIdToRPOId.put(3, 2);
-    expectedSortedIdToRPOId.put(4, 3);
-    expectedSortedIdToRPOId.put(5, 4);
+    expectedSortedIdToRPOId.put(4, 4);
+    expectedSortedIdToRPOId.put(5, 3);
     expectedSortedIdToRPOId.put(6, 5);
 
     for (BasicBlock<?> block : RPO) {
       Integer sortedId = blockToSortedId.get(block);
       Integer rpoId = blockToRPOId.get(block);
       Integer expectedRPOId = expectedSortedIdToRPOId.get(sortedId);
+
       assertEquals(expectedRPOId, rpoId);
     }
   }

--- a/sootup.core/src/test/java/sootup/core/graph/ReversePostOrderTraversalTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/ReversePostOrderTraversalTest.java
@@ -3,6 +3,7 @@ package sootup.core.graph;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import sootup.core.jimple.basic.Local;
@@ -20,12 +21,16 @@ public class ReversePostOrderTraversalTest {
   @Test
   void testReversePostorderTraversal() {
     MutableBlockStmtGraph graph = createStmtGraph();
-    Map<BasicBlock<?>, Integer> blockToSortedId = new HashMap<>();
+    Map<BasicBlock<?>, Integer> blockToId = new HashMap<>();
     Map<BasicBlock<?>, Integer> blockToRPOId = new HashMap<>();
-    // assign sorted ids according to MutableBlockStmtGraph.getBlocksSorted
+    // assign ids according to blocks sorted by BasicBlock::toString
+    List<? extends BasicBlock<?>> blocks =
+        graph.getBlocks().stream()
+            .sorted(Comparator.comparing(BasicBlock::toString))
+            .collect(Collectors.toList());
     int i = 0;
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      blockToSortedId.put(block, i);
+    for (BasicBlock<?> block : blocks) {
+      blockToId.put(block, i);
       i++;
     }
 
@@ -38,18 +43,18 @@ public class ReversePostOrderTraversalTest {
     }
 
     Map<Integer, Integer> expectedSortedIdToRPOId = new HashMap<>();
-    expectedSortedIdToRPOId.put(0, 0);
-    expectedSortedIdToRPOId.put(1, 1);
-    expectedSortedIdToRPOId.put(2, 6);
-    expectedSortedIdToRPOId.put(3, 2);
-    expectedSortedIdToRPOId.put(4, 4);
-    expectedSortedIdToRPOId.put(5, 3);
-    expectedSortedIdToRPOId.put(6, 5);
+    expectedSortedIdToRPOId.put(0, 5);
+    expectedSortedIdToRPOId.put(1, 2);
+    expectedSortedIdToRPOId.put(2, 1);
+    expectedSortedIdToRPOId.put(3, 0);
+    expectedSortedIdToRPOId.put(4, 3);
+    expectedSortedIdToRPOId.put(5, 4);
+    expectedSortedIdToRPOId.put(6, 6);
 
     for (BasicBlock<?> block : RPO) {
-      Integer sortedId = blockToSortedId.get(block);
+      Integer id = blockToId.get(block);
       Integer rpoId = blockToRPOId.get(block);
-      Integer expectedRPOId = expectedSortedIdToRPOId.get(sortedId);
+      Integer expectedRPOId = expectedSortedIdToRPOId.get(id);
 
       assertEquals(expectedRPOId, rpoId);
     }

--- a/sootup.core/src/test/java/sootup/core/graph/ReversePostOrderTraversalTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/ReversePostOrderTraversalTest.java
@@ -3,7 +3,6 @@ package sootup.core.graph;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import sootup.core.jimple.basic.Local;
@@ -15,78 +14,47 @@ import sootup.core.jimple.common.stmt.*;
 import sootup.core.types.PrimitiveType;
 
 @Tag("Java8")
-public class DominanceFinderTest {
-
+public class ReversePostOrderTraversalTest {
   StmtPositionInfo noPosInfo = StmtPositionInfo.getNoStmtPositionInfo();
 
   @Test
-  public void testDominanceFinder() {
+  void testReversePostorderTraversal() {
     MutableBlockStmtGraph graph = createStmtGraph();
-    Map<BasicBlock<?>, Integer> blockToId = new HashMap<>();
-    // assign ids according to getBlocksSorted order
+    Map<BasicBlock<?>, Integer> blockToSortedId = new HashMap<>();
+    Map<BasicBlock<?>, Integer> blockToRPOId = new HashMap<>();
+    // assign sorted ids according to MutableBlockStmtGraph.getBlocksSorted
     int i = 0;
     for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      blockToId.put(block, i);
+      blockToSortedId.put(block, i);
       i++;
     }
 
-    DominanceFinder dom = new DominanceFinder(graph);
-
-    Map<Integer, Set<Integer>> expectedFrontiers = new HashMap<>();
-    expectedFrontiers.put(0, new HashSet<>());
-    expectedFrontiers.put(1, new HashSet<>(Collections.singletonList(1)));
-    expectedFrontiers.put(2, new HashSet<>());
-    expectedFrontiers.put(3, new HashSet<>(Collections.singletonList(1)));
-    expectedFrontiers.put(4, new HashSet<>(Collections.singletonList(6)));
-    expectedFrontiers.put(5, new HashSet<>(Collections.singletonList(6)));
-    expectedFrontiers.put(6, new HashSet<>(Collections.singletonList(1)));
-
-    Map<Integer, Integer> expectedDominators = new HashMap<>();
-    expectedDominators.put(0, -1);
-    expectedDominators.put(1, 0);
-    expectedDominators.put(2, 1);
-    expectedDominators.put(3, 1);
-    expectedDominators.put(4, 3);
-    expectedDominators.put(5, 3);
-    expectedDominators.put(6, 3);
-
-    // check dominators
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      Integer dominatorId = -1;
-      BasicBlock<?> dominator = dom.getImmediateDominator(block);
-      if (dominator != null) {
-        dominatorId = blockToId.get(dominator);
-      }
-      Integer expectedId = expectedDominators.get(blockToId.get(block));
-      assertEquals(expectedId, dominatorId);
+    // assign rpo ids according to ReversePostOrderBlockTraversal.getOrder
+    Iterable<BasicBlock<?>> RPO = new ReversePostOrderBlockTraversal(graph).getOrder();
+    i = 0;
+    for (BasicBlock<?> block : RPO) {
+      blockToRPOId.put(block, i);
+      i++;
     }
 
-    // check frontiers
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      Set<BasicBlock<?>> frontier = dom.getDominanceFrontiers(block);
-      Set<Integer> frontierIds = frontier.stream().map(blockToId::get).collect(Collectors.toSet());
-      Set<Integer> expectedIds = expectedFrontiers.get(blockToId.get(block));
+    Map<Integer, Integer> expectedSortedIdToRPOId = new HashMap<>();
+    expectedSortedIdToRPOId.put(0, 0);
+    expectedSortedIdToRPOId.put(1, 1);
+    expectedSortedIdToRPOId.put(2, 6);
+    expectedSortedIdToRPOId.put(3, 2);
+    expectedSortedIdToRPOId.put(4, 3);
+    expectedSortedIdToRPOId.put(5, 4);
+    expectedSortedIdToRPOId.put(6, 5);
 
-      assertEquals(expectedIds, frontierIds);
-    }
-  }
-
-  @Test
-  public void testBlockToIdxInverse() {
-    MutableBlockStmtGraph graph = createStmtGraph();
-    DominanceFinder dom = new DominanceFinder(graph);
-
-    // check that getBlockToIdx and getIdxToBlock are inverses
-    for (BasicBlock<?> block : graph.getBlocksSorted()) {
-      List<BasicBlock<?>> idxToBlock = dom.getIdxToBlock();
-      Map<BasicBlock<?>, Integer> blockToIdx = dom.getBlockToIdx();
-      assertEquals(block, idxToBlock.get(blockToIdx.get(block)));
+    for (BasicBlock<?> block : RPO) {
+      Integer sortedId = blockToSortedId.get(block);
+      Integer rpoId = blockToRPOId.get(block);
+      Integer expectedRPOId = expectedSortedIdToRPOId.get(sortedId);
+      assertEquals(expectedRPOId, rpoId);
     }
   }
 
   private MutableBlockStmtGraph createStmtGraph() {
-    // reconstruct the example given in
-    // https://soot-oss.github.io/SootUp/v1.1.2/advanced-topics/#dominancefinder.
     MutableBlockStmtGraph graph = new MutableBlockStmtGraph();
 
     Local l1 = new Local("l1", PrimitiveType.IntType.getInstance());


### PR DESCRIPTION
# Summary
Implement RPO Traversal to Enhance CFG Analysis in Soot

# Details
This PR addresses the specific issue raised in the Issue #923 concerning the potential problems due to the lack of Reverse Post-Order (RPO) traversal in the dominance analysis.

 The proposed changes introduce an RPO traversal algorithm, which is integrated into the existing `ForwardStmtGraph` and `BackwardStmtGraph` via the `getBlocksSorted` interface. Additionally, the changes apply RPO in the `DominanceFinder` to enhance the accuracy and performance of dominator calculations.

Key changes include:

- Implementation of an PO traversal algorithm in `sootup/core/graph/ReversePostOrderBlockTraversal.java` and create RPO one as a wrapper of PO.
- Integration of RPO/PO traversal into `ForwardStmtGraph` and `BackwardStmtGraph`.
- Application of RPO in `DominanceFinder` to ensure the correctness of dominator tree generation.
- Correction in handling of the CFG head node in `DominanceFinder`(the head node should not have an immediate dominator). This was addressed by removing the `@Nonnull` annotation from `getImmediateDominator` and allowing a return value of null when the input is the head node.
- Addition of tests for `DominatorFinder`, `PostDominatorFinder`, `PostOrderBlockTraversal`, `ReversePostOrderBlockTraversal` to verify the fixes.

Thank you for reviewing this pull request and considering this update!