### PR TITLE
Fix Type.getValueBitSize in case of a CharType

### DIFF
--- a/sootup.core/src/main/java/sootup/core/types/Type.java
+++ b/sootup.core/src/main/java/sootup/core/types/Type.java
@@ -68,7 +68,7 @@ public abstract class Type implements Acceptor<TypeVisitor> {
     if (type instanceof PrimitiveType.ByteType) {
       return 8;
     }
-    if (type instanceof PrimitiveType.ShortType) {
+    if (type instanceof PrimitiveType.ShortType || type instanceof PrimitiveType.CharType) {
       return 16;
     }
     if (type instanceof PrimitiveType.IntType || type instanceof PrimitiveType.FloatType) {

--- a/sootup.core/src/test/java/sootup/core/types/TypeTest.java
+++ b/sootup.core/src/test/java/sootup/core/types/TypeTest.java
@@ -1,0 +1,14 @@
+package sootup.core.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TypeTest {
+
+  @Test
+  public void testValueBitSize() {
+    int charValueBitSize = Type.getValueBitSize(PrimitiveType.getChar());
+    assertEquals(16, charValueBitSize);
+  }
+}


### PR DESCRIPTION
According to jls-4.2 [1], the value bit size of a char is 16 bit. The old code
returned 32 bit.

Note that the added TypeTest is not executed by default, when running
"mvn test". Since other tests are also affected, I assume this is the
intended behavior.

[1] https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.2