### PR TITLE
Avoid a potential CCE in Position.equals

### DIFF
--- a/sootup.core/src/main/java/sootup/core/model/Position.java
+++ b/sootup.core/src/main/java/sootup/core/model/Position.java
@@ -56,7 +56,7 @@ public abstract class Position implements Comparable<Position> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    FullPosition position = (FullPosition) o;
+    Position position = (Position) o;
     return getFirstLine() == position.getFirstLine()
         && getFirstCol() == position.getFirstCol()
         && getLastLine() == position.getLastLine()

--- a/sootup.core/src/main/java/sootup/core/model/Position.java
+++ b/sootup.core/src/main/java/sootup/core/model/Position.java
@@ -53,7 +53,7 @@ public abstract class Position implements Comparable<Position> {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Position)) {
       return false;
     }
     Position position = (Position) o;


### PR DESCRIPTION
The old code in sootup.core.model.Position.equals always casts the passed argument to a FullPosition. However, in theory, it is possible that there are multiple subclasses of Position. Hence, the cast could potentially result in a CCE. In order to avoid this, just cast the passed argument to Position itself, which is always safe (due to the previous checks).