### PR TITLE
Fix typo in `jimple.md`

### DIFF
--- a/docs/jimple.md
+++ b/docs/jimple.md
@@ -504,7 +504,7 @@ A Trap is a mechanism to model exceptional flow.
       }
     }
     /*
-      By calling getTraps() method, we can get the Traip chain.
+      By calling getTraps() method, we can get the trap chain.
       For the above jimple code, we have the below trap:
       Trap :
       begin  : $stack5 = <java.lang.System: java.io.PrintStream out>


### PR DESCRIPTION
I think "traip" really means "trap" in the context of "traip chain"