### PR TITLE
add `entryInitialFlow` API

### DIFF
--- a/sootup.analysis/src/main/java/sootup/analysis/intraprocedural/AbstractFlowAnalysis.java
+++ b/sootup.analysis/src/main/java/sootup/analysis/intraprocedural/AbstractFlowAnalysis.java
@@ -54,6 +54,11 @@ public abstract class AbstractFlowAnalysis<F> {
   @Nonnull
   protected abstract F newInitialFlow();
 
+  /** Returns the initial flow value for entry/ exit graph nodes. */
+  protected F entryInitialFlow() {
+    return newInitialFlow();
+  }
+
   /** Determines whether <code>entryInitialFlow()</code> is applied to trap handlers. */
   // FIXME: [ms] implement as an option
   protected boolean treatTrapHandlersAsEntries() {

--- a/sootup.analysis/src/main/java/sootup/analysis/intraprocedural/FlowAnalysis.java
+++ b/sootup.analysis/src/main/java/sootup/analysis/intraprocedural/FlowAnalysis.java
@@ -453,7 +453,7 @@ public abstract class FlowAnalysis<A> extends AbstractFlowAnalysis<A> {
         Orderer.newUniverse(
             graph,
             isForward ? AnalysisDirection.FORWARD : AnalysisDirection.BACKWARD,
-                entryInitialFlow());
+            entryInitialFlow());
     initFlow(universe, inFlow, outFlow);
 
     Queue<Entry<A>> q = UniverseSortedPriorityQueue.of(universe);

--- a/sootup.analysis/src/main/java/sootup/analysis/intraprocedural/FlowAnalysis.java
+++ b/sootup.analysis/src/main/java/sootup/analysis/intraprocedural/FlowAnalysis.java
@@ -453,7 +453,7 @@ public abstract class FlowAnalysis<A> extends AbstractFlowAnalysis<A> {
         Orderer.newUniverse(
             graph,
             isForward ? AnalysisDirection.FORWARD : AnalysisDirection.BACKWARD,
-            newInitialFlow());
+                entryInitialFlow());
     initFlow(universe, inFlow, outFlow);
 
     Queue<Entry<A>> q = UniverseSortedPriorityQueue.of(universe);


### PR DESCRIPTION
### Summary
Added `entryInitialFlow` to allow customization of the initial flow value for entry and exit points. The default value is `newInitialFlow()`.
### Details
- **Feature**: `entryInitialFlow`
  - **Purpose**: To allow users to customize the initial flow value for entry and exit points in the analysis.
### Issue
This closes #934.