### PR TITLE
issue 967 Github Issue Template error

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_TEMPLATE.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Missing Feature
       description: Please describe the wanted functionality in detail. If possible enhance it with examples and/or scientific publications.
-      value: ""
+      value: Please describe the missing feature here..
     validations:
       required: true
 


### PR DESCRIPTION
Empty strings, strings consisting only of whitespaces, are not permissible when an attribute expects a string.

Ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#bodyi-label-must-be-a-string
