### PR TITLE
remove super keyword in jimple in Legacy Mode

### DIFF
--- a/sootup.core/src/main/java/sootup/core/util/printer/JimplePrinter.java
+++ b/sootup.core/src/main/java/sootup/core/util/printer/JimplePrinter.java
@@ -136,6 +136,10 @@ public class JimplePrinter {
       */
 
       EnumSet<ClassModifier> modifiers = EnumSet.copyOf(cl.getModifiers());
+      // Jimple parser in Soot gives error with super keyword in class modifiers
+      if (options.contains(Option.LegacyMode)) {
+        modifiers.remove(ClassModifier.SUPER);
+      }
       // remove unwanted modifier combinations
       if (cl.isInterface() && ClassModifier.isAbstract(modifiers)) {
         modifiers.remove(ClassModifier.ABSTRACT);


### PR DESCRIPTION
remove super keyword in jimple of whole class to avoid error when parsing jimple via soot