### PR TITLE
Update dex2jar

### DIFF
--- a/sootup.java.bytecode.frontend/pom.xml
+++ b/sootup.java.bytecode.frontend/pom.xml
@@ -28,17 +28,17 @@
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-util</artifactId>
-			<version>9.5</version>
+			<version>9.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-commons</artifactId>
-			<version>9.5</version>
+			<version>9.7</version>
 		</dependency>
 		<dependency>
 			<groupId>de.femtopedia.dex2jar</groupId>
 			<artifactId>dex2jar</artifactId>
-			<version>2.4.16</version>
+			<version>2.4.22</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Updates dex2jar and ASM to their respective latest versions. I have squashed quite a few bugs within dex2jar since the last update :)
~~CI might be failing right now since the artifact might not have finished syncing to Central. Should work in around 15-30 minutes at most, though!~~

Edit: CI seems to have worked already, nice!