### PR TITLE
fix lns Interger1Type, Interger127Type, etc

### DIFF
--- a/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
+++ b/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
@@ -32,7 +32,6 @@ import sootup.core.transform.BodyInterceptor;
 import sootup.core.types.Type;
 import sootup.core.views.View;
 
-// https://github.com/Sable/soot/blob/master/src/main/java/soot/jimple/toolkits/scalar/LocalNameStandardizer.java
 
 /** @author Zun Wang */
 public class LocalNameStandardizer implements BodyInterceptor {

--- a/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
+++ b/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
@@ -32,7 +32,6 @@ import sootup.core.transform.BodyInterceptor;
 import sootup.core.types.Type;
 import sootup.core.views.View;
 
-
 /** @author Zun Wang */
 public class LocalNameStandardizer implements BodyInterceptor {
 

--- a/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
+++ b/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
@@ -29,12 +29,8 @@ import sootup.core.jimple.basic.LocalGenerator;
 import sootup.core.jimple.common.stmt.Stmt;
 import sootup.core.model.Body;
 import sootup.core.transform.BodyInterceptor;
-import sootup.core.types.PrimitiveType;
 import sootup.core.types.Type;
 import sootup.core.views.View;
-import sootup.interceptors.typeresolving.types.AugmentIntegerTypes;
-import sootup.interceptors.typeresolving.types.BottomType;
-import sootup.interceptors.typeresolving.types.TopType;
 
 // https://github.com/Sable/soot/blob/master/src/main/java/soot/jimple/toolkits/scalar/LocalNameStandardizer.java
 
@@ -70,20 +66,6 @@ public class LocalNameStandardizer implements BodyInterceptor {
       Local local = iterator.next();
       Local newLocal;
       Type type = local.getType();
-
-      if (type instanceof BottomType || type instanceof TopType) {
-        // TODO: log that likely the jimple is not formed correctly
-        // TODO: handle module signatures
-        type = view.getIdentifierFactory().getClassType("java.lang.Object");
-      }
-      if (type instanceof AugmentIntegerTypes.Integer1Type) {
-        type = PrimitiveType.BooleanType.getInstance();
-      }
-      if (type instanceof AugmentIntegerTypes.Integer127Type
-          || type instanceof AugmentIntegerTypes.Integer32767Type) {
-        type = PrimitiveType.IntType.getInstance();
-      }
-
       newLocal = lgen.generateLocal(type);
       builder.replaceLocal(local, newLocal);
     }

--- a/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
+++ b/sootup.interceptors/src/main/java/sootup/interceptors/LocalNameStandardizer.java
@@ -29,9 +29,12 @@ import sootup.core.jimple.basic.LocalGenerator;
 import sootup.core.jimple.common.stmt.Stmt;
 import sootup.core.model.Body;
 import sootup.core.transform.BodyInterceptor;
+import sootup.core.types.PrimitiveType;
 import sootup.core.types.Type;
 import sootup.core.views.View;
+import sootup.interceptors.typeresolving.types.AugmentIntegerTypes;
 import sootup.interceptors.typeresolving.types.BottomType;
+import sootup.interceptors.typeresolving.types.TopType;
 
 // https://github.com/Sable/soot/blob/master/src/main/java/soot/jimple/toolkits/scalar/LocalNameStandardizer.java
 
@@ -68,10 +71,17 @@ public class LocalNameStandardizer implements BodyInterceptor {
       Local newLocal;
       Type type = local.getType();
 
-      if (type instanceof BottomType) {
+      if (type instanceof BottomType || type instanceof TopType) {
         // TODO: log that likely the jimple is not formed correctly
         // TODO: handle module signatures
         type = view.getIdentifierFactory().getClassType("java.lang.Object");
+      }
+      if (type instanceof AugmentIntegerTypes.Integer1Type) {
+        type = PrimitiveType.BooleanType.getInstance();
+      }
+      if (type instanceof AugmentIntegerTypes.Integer127Type
+          || type instanceof AugmentIntegerTypes.Integer32767Type) {
+        type = PrimitiveType.IntType.getInstance();
       }
 
       newLocal = lgen.generateLocal(type);

--- a/sootup.interceptors/src/main/java/sootup/interceptors/typeresolving/TypeResolver.java
+++ b/sootup.interceptors/src/main/java/sootup/interceptors/typeresolving/TypeResolver.java
@@ -81,7 +81,8 @@ public class TypeResolver {
         new TypePromotionVisitor(builder, evalFunction, hierarchy);
     typings = typings.stream().map(promotionVisitor::getPromotedTyping).collect(Collectors.toSet());
 
-    // Promote `null`/`BottomType` types to `Object`.
+    // Promote `null`/`BottomType`/'TopType' types to `Object`, and other types which have
+    // UnsupportedOperation in TypePromotionVisitor.
     for (Typing typing : typings) {
       for (Local local : locals) {
         typing.set(local, convertUnderspecifiedType(typing.getType(local)));
@@ -353,6 +354,12 @@ public class TypeResolver {
       // It is probably possible to use the debug information to choose a type here, but that
       // complexity is not worth it for such an edge case.
       return objectType;
+    } else if (type instanceof AugmentIntegerTypes.Integer1Type) {
+      return PrimitiveType.getBoolean();
+    } else if (type instanceof AugmentIntegerTypes.Integer127Type) {
+      return PrimitiveType.getByte();
+    } else if (type instanceof AugmentIntegerTypes.Integer32767Type) {
+      return PrimitiveType.getShort();
     } else {
       return type;
     }


### PR DESCRIPTION
fix types created by type assigner, later using LocalNameStandardiser handle types such as TopType, Interger1Type, Interger127Type, etc.