### PR TITLE
Use canonical dest dir path in ZipSlip check

### DIFF
--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/WarArchiveAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/WarArchiveAnalysisInputLocation.java
@@ -154,8 +154,9 @@ final class WarArchiveAnalysisInputLocation extends DirectoryBasedAnalysisInputL
         Path filepath = destDirectory.resolve(zipEntry.getName());
         final File file = filepath.toFile();
 
-        String canonicalPathStr = file.getCanonicalPath();
-        if (!canonicalPathStr.startsWith(destDirectory + File.separator)) {
+        String canonicalFilepathStr = file.getCanonicalPath();
+        String canonicalDestDirStr = dest.getCanonicalPath();
+        if (!canonicalFilepathStr.startsWith(canonicalDestDirStr + File.separator)) {
           throw new IllegalArgumentException(
               "ZipSlip Attack Mitigated: ZipEntry points outside of the target dir: "
                   + file.getName());


### PR DESCRIPTION
I was attempting to build this project on my Mac, and one test -- `PathBasedAnalysisInputLocationTest#testWar` -- failed.  It seems that at least on my Mac, the destination directory is not canonical, and so the check here incorrectly fails.  The test passes once I canonicalize the destination directory.