### PR TITLE
Fixed the example in the callgraph section for Qilin Pointer Analysis

### DIFF
--- a/docs/callgraphs.md
+++ b/docs/callgraphs.md
@@ -186,8 +186,8 @@ You can construct a call graph with Qilin as follows:
 
     ```java
     String MAINCLASS = "dacapo.antlr.Main"; // just an example
-    PTAPattern ptaPattern = new PTAPattern("insens"); // "2o"=>2OBJ, "1c"=>1CFA, etc.
-    PTA pta = PTAFactory.createPTA(ptaPattern, view, MAINCLASS);
+    PTAConfig.v().getPtaConfig().ptaPattern = new PTAPattern("insens"); // "2o"=>2OBJ, "1c"=>1CFA, etc.
+    PTA pta = PTAFactory.createPTA(PTAConfig.v().getPtaConfig().ptaPattern, view, MAINCLASS);
     pta.run();
     CallGraph cg = pta.getCallGraph();
     ```


### PR DESCRIPTION
This PR fixes an issue where the sample code failed to execute due to the configuration class (CoreConfig) not being properly initialized.
at qilin.CoreConfig.v(CoreConfig.java:28)
	at qilin.core.builder.FakeMainFactory.getEntryPoints(FakeMainFactory.java:131)
	at qilin.core.builder.FakeMainFactory.makeFakeMain(FakeMainFactory.java:165)
	at qilin.core.builder.FakeMainFactory.<init>(FakeMainFactory.java:89)
	at qilin.core.PTAScene.<init>(PTAScene.java:57)
	at qilin.driver.PTAFactory.createPTA(PTAFactory.java:30)