### PR TITLE
sootup.core: fix some compiler warnings wrt. generics

### DIFF
--- a/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java
+++ b/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java
@@ -120,7 +120,7 @@ public class OverridingClassSource extends SootClassSource {
   public Collection<SootMethod> resolveMethods() throws ResolveException {
     return overriddenSootMethods != null
         ? overriddenSootMethods
-        : (Collection<SootMethod>) delegate.resolveMethods();
+        : Collections.unmodifiableCollection(delegate.resolveMethods());
   }
 
   @NonNull
@@ -128,7 +128,7 @@ public class OverridingClassSource extends SootClassSource {
   public Collection<SootField> resolveFields() throws ResolveException {
     return overriddenSootFields != null
         ? overriddenSootFields
-        : (Collection<SootField>) delegate.resolveFields();
+        : Collections.unmodifiableCollection(delegate.resolveFields());
   }
 
   @NonNull
@@ -142,7 +142,7 @@ public class OverridingClassSource extends SootClassSource {
   public Set<ClassType> resolveInterfaces() {
     return overriddenInterfaces != null
         ? overriddenInterfaces
-        : (Set<ClassType>) delegate.resolveInterfaces();
+        : Collections.unmodifiableSet(delegate.resolveInterfaces());
   }
 
   @NonNull
@@ -150,7 +150,7 @@ public class OverridingClassSource extends SootClassSource {
   public Optional<ClassType> resolveSuperclass() {
     return overriddenSuperclass != null
         ? overriddenSuperclass
-        : (Optional<ClassType>) delegate.resolveSuperclass();
+        : delegate.resolveSuperclass().map(c -> (ClassType) c);
   }
 
   @NonNull
@@ -158,7 +158,7 @@ public class OverridingClassSource extends SootClassSource {
   public Optional<ClassType> resolveOuterClass() {
     return overriddenOuterClass != null
         ? overriddenOuterClass
-        : (Optional<ClassType>) delegate.resolveOuterClass();
+        : delegate.resolveOuterClass().map(c -> (ClassType) c);
   }
 
   @NonNull

--- a/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java
@@ -28,9 +28,9 @@ import sootup.core.jimple.common.stmt.Stmt;
 /**
  * @author Zun Wang
  */
-public class BackwardsStmtGraph extends ForwardingStmtGraph {
+public class BackwardsStmtGraph<V extends BasicBlock<V>> extends ForwardingStmtGraph<V> {
 
-  public BackwardsStmtGraph(@NonNull StmtGraph<?> stmtGraph) {
+  public BackwardsStmtGraph(@NonNull StmtGraph<V> stmtGraph) {
     super(stmtGraph);
   }
 

--- a/sootup.core/src/main/java/sootup/core/graph/BlockAnalysisDirection.java
+++ b/sootup.core/src/main/java/sootup/core/graph/BlockAnalysisDirection.java
@@ -36,7 +36,7 @@ public enum BlockAnalysisDirection {
   POSTORDERBACKWARD {
     @Override
     @NonNull List<BasicBlock<?>> getPredecessors(BasicBlock<?> block) {
-      return (List<BasicBlock<?>>) block.getSuccessors();
+      return Collections.unmodifiableList(block.getSuccessors());
     }
 
     @NonNull
@@ -49,7 +49,7 @@ public enum BlockAnalysisDirection {
   REVERSEPOSTORDERFORWARD {
     @Override
     @NonNull List<BasicBlock<?>> getPredecessors(BasicBlock<?> block) {
-      return (List<BasicBlock<?>>) block.getPredecessors();
+      return Collections.unmodifiableList(block.getPredecessors());
     }
 
     @NonNull

--- a/sootup.core/src/main/java/sootup/core/graph/BlockGraphIterator.java
+++ b/sootup.core/src/main/java/sootup/core/graph/BlockGraphIterator.java
@@ -34,14 +34,14 @@ import sootup.core.util.DotExporter;
 /** Iterates over the blocks */
 public class BlockGraphIterator implements Iterator<BasicBlock<?>> {
 
-  private final StmtGraph stmtGraph;
+  private final StmtGraph<?> stmtGraph;
   @NonNull private final ArrayDeque<BasicBlock<?>> trapHandlerBlocks = new ArrayDeque<>();
 
   @NonNull private final ArrayDeque<BasicBlock<?>> nestedBlocks = new ArrayDeque<>();
   @NonNull private final ArrayDeque<BasicBlock<?>> otherBlocks = new ArrayDeque<>();
   @NonNull private final Set<BasicBlock<?>> iteratedBlocks;
 
-  public BlockGraphIterator(StmtGraph stmtGraph) {
+  public BlockGraphIterator(StmtGraph<?> stmtGraph) {
     this.stmtGraph = stmtGraph;
     final Collection<? extends BasicBlock<?>> blocks = stmtGraph.getBlocks();
     iteratedBlocks = new LinkedHashSet<>(blocks.size(), 1);

--- a/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
+++ b/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java
@@ -39,7 +39,7 @@ public class DominanceFinder {
   private List<BasicBlock<?>> blocks;
   private Map<BasicBlock<?>, Integer> blockToIdx = new HashMap<>();
   private int[] doms;
-  private ArrayList<Integer>[] domFrontiers;
+  private List<List<Integer>> domFrontiers;
   private BlockAnalysisDirection direction;
 
   public DominanceFinder(StmtGraph<?> blockGraph) {
@@ -108,9 +108,9 @@ public class DominanceFinder {
     }
 
     // initialize domFrontiers
-    domFrontiers = new ArrayList[blocks.size()];
-    for (int i = 0; i < domFrontiers.length; i++) {
-      domFrontiers[i] = new ArrayList<>();
+    domFrontiers = new ArrayList<>(blocks.size());
+    for (int i = 0; i < blocks.size(); i++) {
+      domFrontiers.add(new ArrayList<>());
     }
 
     doms[0] = -1;
@@ -122,7 +122,7 @@ public class DominanceFinder {
         for (BasicBlock<?> pred : preds) {
           int predId = blockToIdx.get(pred);
           while (predId != -1 && predId != doms[blockId]) {
-            domFrontiers[predId].add(blockId);
+            domFrontiers.get(predId).add(blockId);
             predId = doms[predId];
           }
         }
@@ -130,9 +130,9 @@ public class DominanceFinder {
     }
 
     if (direction == BlockAnalysisDirection.POSTORDERBACKWARD) {
-      for (int i = 0; i < domFrontiers.length; i++) {
-        if (domFrontiers[i].contains(i)) {
-          domFrontiers[i].remove(Integer.valueOf(i));
+      for (int i = 0; i < domFrontiers.size(); i++) {
+        if (domFrontiers.get(i).contains(i)) {
+          domFrontiers.get(i).remove(Integer.valueOf(i));
         }
       }
     }
@@ -168,7 +168,7 @@ public class DominanceFinder {
     }
     int idx = blockToIdx.get(block);
     Set<BasicBlock<?>> dFs = new HashSet<>();
-    ArrayList<Integer> dFs_idx = this.domFrontiers[idx];
+    List<Integer> dFs_idx = this.domFrontiers.get(idx);
     for (Integer i : dFs_idx) {
       dFs.add(blocks.get(i));
     }

--- a/sootup.core/src/main/java/sootup/core/graph/DominanceTree.java
+++ b/sootup.core/src/main/java/sootup/core/graph/DominanceTree.java
@@ -36,7 +36,7 @@ public class DominanceTree {
 
   private List<BasicBlock<?>> blocks;
   private Map<BasicBlock<?>, Integer> blockToIdx;
-  private List<Integer>[] children;
+  private List<List<Integer>> children;
   private int[] parents;
 
   public DominanceTree(@NonNull DominanceFinder dominanceFinder) {
@@ -44,17 +44,17 @@ public class DominanceTree {
     this.blockToIdx = dominanceFinder.getBlockToIdx();
     int[] iDoms = dominanceFinder.getImmediateDominators();
     int treeSize = iDoms.length;
-    children = new ArrayList[treeSize];
+    children = new ArrayList<>(treeSize);
     parents = new int[treeSize];
     for (int i = 0; i < treeSize; i++) {
-      children[i] = new ArrayList<>();
+      children.add(new ArrayList<>());
       parents[i] = -1;
     }
 
     for (int i = 0; i < treeSize; i++) {
       if (iDoms[i] != -1 && iDoms[i] != i) {
         parents[i] = iDoms[i];
-        children[iDoms[i]].add(i);
+        children.get(iDoms[i]).add(i);
       }
     }
   }
@@ -63,7 +63,7 @@ public class DominanceTree {
   public List<BasicBlock<?>> getChildren(@NonNull BasicBlock<?> block) {
     List<BasicBlock<?>> childList = new ArrayList<>();
     int idx = blockToIdx.get(block);
-    for (int i : children[idx]) {
+    for (int i : children.get(idx)) {
       childList.add(blocks.get(i));
     }
     return childList;

--- a/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockIterator.java
+++ b/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockIterator.java
@@ -35,7 +35,10 @@ public class PostOrderBlockIterator implements BlockIterator {
 
   public PostOrderBlockIterator(@NonNull BasicBlock<?> startNode) {
     visitNode(startNode);
-    stack.push(new Frame(startNode, ((List<BasicBlock<?>>) startNode.getSuccessors()).iterator()));
+    stack.push(
+        new Frame(
+            startNode,
+            Collections.<BasicBlock<?>>unmodifiableList(startNode.getSuccessors()).iterator()));
   }
 
   private boolean visitNode(@NonNull BasicBlock<?> node) {
@@ -57,7 +60,7 @@ public class PostOrderBlockIterator implements BlockIterator {
         if (visitNode(succ)) {
           List<BasicBlock<?>> esuccs =
               succ.getExceptionalSuccessors().values().stream().collect(Collectors.toList());
-          List<BasicBlock<?>> succs = (List<BasicBlock<?>>) succ.getSuccessors();
+          List<BasicBlock<?>> succs = new ArrayList<>(succ.getSuccessors());
           succs.addAll(esuccs);
           stack.push(new Frame(succ, succs.iterator()));
         }

--- a/sootup.core/src/main/java/sootup/core/jimple/javabytecode/stmt/JSwitchStmt.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/javabytecode/stmt/JSwitchStmt.java
@@ -288,11 +288,11 @@ public class JSwitchStmt extends AbstractStmt implements BranchingStmt {
     @NonNull
     @Override
     public <T> T[] toArray(@NonNull T[] ts) {
-      T[] intConstants = (T[]) new Object[to - from + 1];
+      List<IntConstant> intConstants = new ArrayList<>(to - from + 1);
       for (int i = 0; i < size(); i++) {
-        intConstants[i] = (T) IntConstant.getInstance(from + i);
+        intConstants.add(IntConstant.getInstance(from + i));
       }
-      return intConstants;
+      return intConstants.toArray(ts);
     }
 
     @Override

--- a/sootup.core/src/main/java/sootup/core/signatures/SootClassMemberSignature.java
+++ b/sootup.core/src/main/java/sootup/core/signatures/SootClassMemberSignature.java
@@ -82,7 +82,7 @@ public abstract class SootClassMemberSignature<V extends SootClassMemberSubSigna
       return false;
     }
 
-    SootClassMemberSignature<V> that = (SootClassMemberSignature<V>) o;
+    SootClassMemberSignature<?> that = (SootClassMemberSignature<?>) o;
     return Objects.equal(declClassSignature, that.declClassSignature)
         && Objects.equal(subSignature, that.subSignature);
   }

--- a/sootup.core/src/main/java/sootup/core/util/printer/LabeledStmtPrinter.java
+++ b/sootup.core/src/main/java/sootup/core/util/printer/LabeledStmtPrinter.java
@@ -254,7 +254,7 @@ public abstract class LabeledStmtPrinter extends AbstractStmtPrinter {
    * @return A collection of all the Stmts that are targets of a BranchingStmt
    */
   @NonNull
-  public Collection<Stmt> getLabeledStmts(StmtGraph stmtGraph, List<Trap> traps) {
+  public Collection<Stmt> getLabeledStmts(StmtGraph<?> stmtGraph, List<Trap> traps) {
     Set<Stmt> stmtList = new HashSet<>();
     Collection<Stmt> stmtGraphNodes = stmtGraph.getNodes();
     for (Stmt stmt : stmtGraphNodes) {


### PR DESCRIPTION
```
When compiling sootup.core with -Xlint:unchecked, the following warnings are reported:

[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/signatures/SootClassMemberSignature.java:[85,70] unchecked cast
  required: sootup.core.signatures.SootClassMemberSignature<V>
  found:    java.lang.Object
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/jimple/javabytecode/stmt/JSwitchStmt.java:[291,32] unchecked cast
  required: T[]
  found:    java.lang.Object[]
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/jimple/javabytecode/stmt/JSwitchStmt.java:[293,54] unchecked cast
  required: T
  found:    sootup.core.jimple.common.constant.IntConstant
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java:[123,59] unchecked cast
  required: java.util.Collection<sootup.core.model.SootMethod>
  found:    @org.jspecify.annotations.NonNull java.util.Collection<capture#1 of ? extends sootup.core.model.SootMethod>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java:[131,57] unchecked cast
  required: java.util.Collection<sootup.core.model.SootField>
  found:    @org.jspecify.annotations.NonNull java.util.Collection<capture#2 of ? extends sootup.core.model.SootField>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java:[145,54] unchecked cast
  required: java.util.Set<sootup.core.types.ClassType>
  found:    @org.jspecify.annotations.NonNull java.util.Set<capture#3 of ? extends sootup.core.types.ClassType>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java:[153,59] unchecked cast
  required: java.util.Optional<sootup.core.types.ClassType>
  found:    @org.jspecify.annotations.NonNull java.util.Optional<capture#4 of ? extends sootup.core.types.ClassType>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/frontend/OverridingClassSource.java:[161,59] unchecked cast
  required: java.util.Optional<sootup.core.types.ClassType>
  found:    @org.jspecify.annotations.NonNull java.util.Optional<capture#5 of ? extends sootup.core.types.ClassType>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java:[34,10] unchecked call to ForwardingStmtGraph(@org.jspecify.annotations.NonNull sootup.core.graph.StmtGraph<V>) as a member of the raw type sootup.core.graph.ForwardingStmtGraph
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java:[44,33] unchecked conversion
  required: @org.jspecify.annotations.NonNull java.util.List<sootup.core.jimple.common.stmt.Stmt>
  found:    java.util.List
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java:[50,46] unchecked method invocation: method unmodifiableCollection in class java.util.Collections is applied to given types
  required: java.util.Collection<? extends T>
  found:    java.util.Collection
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java:[50,46] unchecked conversion
  required: @org.jspecify.annotations.NonNull java.util.Collection<sootup.core.jimple.common.stmt.Stmt>
  found:    java.util.Collection
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java:[63,35] unchecked conversion
  required: @org.jspecify.annotations.NonNull java.util.List<sootup.core.jimple.common.stmt.Stmt>
  found:    java.util.List
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BackwardsStmtGraph.java:[69,37] unchecked conversion
  required: @org.jspecify.annotations.NonNull java.util.List<sootup.core.jimple.common.stmt.Stmt>
  found:    java.util.List
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BlockAnalysisDirection.java:[39,55] unchecked cast
  required: java.util.List<sootup.core.graph.BasicBlock<?>>
  found:    @org.jspecify.annotations.NonNull java.util.List<capture#6 of ?>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BlockAnalysisDirection.java:[52,57] unchecked cast
  required: java.util.List<sootup.core.graph.BasicBlock<?>>
  found:    @org.jspecify.annotations.NonNull java.util.List<capture#7 of ?>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BlockGraphIterator.java:[46,75] unchecked conversion
  required: java.util.Collection<? extends sootup.core.graph.BasicBlock<?>>
  found:    java.util.Collection
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BlockGraphIterator.java:[67,73] unchecked conversion
  required: java.util.Collection<? extends sootup.core.graph.BasicBlock<?>>
  found:    java.util.Collection
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/BlockGraphIterator.java:[190,77] unchecked conversion
  required: java.util.Collection<? extends sootup.core.graph.BasicBlock<?>>
  found:    java.util.Collection
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/DominanceFinder.java:[111,20] unchecked conversion
  required: java.util.ArrayList<java.lang.Integer>[]
  found:    java.util.ArrayList[]
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/DominanceTree.java:[47,16] unchecked conversion
  required: java.util.List<java.lang.Integer>[]
  found:    java.util.ArrayList[]
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockIterator.java:[38,83] unchecked cast
  required: java.util.List<sootup.core.graph.BasicBlock<?>>
  found:    @org.jspecify.annotations.NonNull java.util.List<capture#8 of ?>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/graph/PostOrderBlockIterator.java:[60,79] unchecked cast
  required: java.util.List<sootup.core.graph.BasicBlock<?>>
  found:    @org.jspecify.annotations.NonNull java.util.List<capture#9 of ?>
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/util/printer/LabeledStmtPrinter.java:[259,57] unchecked conversion
  required: java.util.Collection<sootup.core.jimple.common.stmt.Stmt>
  found:    java.util.Collection
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/util/printer/LabeledStmtPrinter.java:[270,26] unchecked method invocation: method addAll in interface java.util.Set is applied to given types
  required: java.util.Collection<? extends E>
  found:    java.util.List
[WARNING] /home/marcus/sootUp/sootup.core/src/main/java/sootup/core/util/printer/LabeledStmtPrinter.java:[270,55] unchecked conversion
  required: java.util.Collection<? extends E>
  found:    java.util.List

This commit fixes all of them.
Note in some cases an immutable list instance is created, whose sole purpose is to pacify the compiler:
- From a running time perspective, this should not be an issue because an unmodifiable list is just an unmodifiable view of the list (no elements are copied, calls are "just" delegated).
- From a memory usage perspective, this should also be fine (at most one additional instance per list).

Note that in PostOrderBlockIterator.visitNode a new list is created for two reasons:
- The list that is returned by BasicBlock.getSuccessors should not be modified because in theory, the list could be, for instance, unmodifiable (List.addAll is an optional operation).
- Pacify the compiler.
```