### PR TITLE
Fix more compiler warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,11 @@
             <version>3.17.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.13.1</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.19.0</version>

--- a/sootup.analysis.interprocedural/src/test/java/sootup/analysis/interprocedural/ifds/IFDSTaintTestSetUp.java
+++ b/sootup.analysis.interprocedural/src/test/java/sootup/analysis/interprocedural/ifds/IFDSTaintTestSetUp.java
@@ -65,7 +65,7 @@ public class IFDSTaintTestSetUp {
             view, Collections.singletonList(entryMethodSignature), false, false);
     IFDSTaintAnalysisProblem problem = new IFDSTaintAnalysisProblem(icfg, entryMethod);
     JimpleIFDSSolver<?, InterproceduralCFG<Stmt, SootMethod>> solver =
-        new JimpleIFDSSolver(problem);
+        new JimpleIFDSSolver<>(problem);
     solver.solve(entryMethod.getDeclaringClassType().getClassName());
     solved = solver;
   }

--- a/sootup.core/pom.xml
+++ b/sootup.core/pom.xml
@@ -42,6 +42,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>

--- a/sootup.core/src/main/java/sootup/core/util/DotExporter.java
+++ b/sootup.core/src/main/java/sootup/core/util/DotExporter.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Sets;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.*;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jspecify.annotations.NonNull;
 import sootup.core.graph.BasicBlock;
 import sootup.core.graph.StmtGraph;

--- a/sootup.core/src/main/java/sootup/core/util/Utils.java
+++ b/sootup.core/src/main/java/sootup/core/util/Utils.java
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.tools.*;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jspecify.annotations.NonNull;
 import sootup.core.jimple.basic.EquivTo;
 import sootup.core.model.Body;

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/conversion/AsmMethodSource.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/conversion/AsmMethodSource.java
@@ -258,7 +258,7 @@ public class AsmMethodSource extends JSRInlinerAdapter implements BodySource {
 
     if (a instanceof ArrayList) {
       List<Object> list = new ArrayList<>();
-      ((ArrayList) a).forEach(e -> list.add(resolveAnnotationsInDefaultValue(e)));
+      ((ArrayList<?>) a).forEach(e -> list.add(resolveAnnotationsInDefaultValue(e)));
       return list;
     }
     return AsmUtil.convertAnnotationValue(a);

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/conversion/AsmUtil.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/conversion/AsmUtil.java
@@ -346,8 +346,8 @@ public final class AsmUtil {
           if (annotationValue instanceof ArrayList
               && !((ArrayList<?>) annotationValue).isEmpty()
               && ((ArrayList<?>) annotationValue).get(0) instanceof AnnotationNode) {
-            final ArrayList<AnnotationNode> annotationValueList =
-                (ArrayList<AnnotationNode>) annotationValue;
+            final List<AnnotationNode> annotationValueList =
+                ((ArrayList<?>) annotationValue).stream().map(av -> (AnnotationNode) av).toList();
 
             paramMap.put(annotationName, createAnnotationUsage(annotationValueList));
           } else if (annotationValue instanceof AnnotationNode) {

--- a/sootup.jimple.frontend/src/test/java/sootup/jimple/frontend/javatestsuite/java6/DeclareEnumWithConstructorTest.java
+++ b/sootup.jimple.frontend/src/test/java/sootup/jimple/frontend/javatestsuite/java6/DeclareEnumWithConstructorTest.java
@@ -21,7 +21,7 @@ public class DeclareEnumWithConstructorTest extends JimpleTestSuiteBase {
                 getDeclaredClassSignature().getFullyQualifiedName() + "$Number"));
     assertTrue(sc.isEnum());
 
-    final Set<SootMethod> methods = (Set<SootMethod>) sc.getMethods();
+    final Set<? extends SootMethod> methods = sc.getMethods();
     assertTrue(methods.stream().anyMatch(m -> m.getSignature().getName().equals("getValue")));
   }
 }


### PR DESCRIPTION
Fix some more compiler warnings wrt. generics and deprecated classes. For the
details, see the individual commit messages.