### PR TITLE
fix/exclude-META-INF-parsing-in-regular-jar-file-and-default-behaviour

### DIFF
--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/ArchiveBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/ArchiveBasedAnalysisInputLocation.java
@@ -84,7 +84,7 @@ public class ArchiveBasedAnalysisInputLocation extends PathBasedAnalysisInputLoc
       @NonNull Path path,
       @NonNull SourceType srcType,
       @NonNull List<BodyInterceptor> bodyInterceptors) {
-    this(path, srcType, bodyInterceptors,  Collections.singletonList(Paths.get("/META-INF")));
+    this(path, srcType, bodyInterceptors, Collections.singletonList(Paths.get("/META-INF")));
   }
 
   public ArchiveBasedAnalysisInputLocation(

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/ArchiveBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/ArchiveBasedAnalysisInputLocation.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -83,7 +84,7 @@ public class ArchiveBasedAnalysisInputLocation extends PathBasedAnalysisInputLoc
       @NonNull Path path,
       @NonNull SourceType srcType,
       @NonNull List<BodyInterceptor> bodyInterceptors) {
-    this(path, srcType, bodyInterceptors, Collections.emptyList());
+    this(path, srcType, bodyInterceptors,  Collections.singletonList(Paths.get("/META-INF")));
   }
 
   public ArchiveBasedAnalysisInputLocation(

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
@@ -63,6 +63,7 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
   @NonNull
   protected final Map<Integer, AnalysisInputLocation> inputLocations = new LinkedHashMap<>();
 
+  /** resembles the desired java version of the used view for this (MultiRelease) Jar  */
   private final int version;
 
   public MultiReleaseJarAnalysisInputLocation(@NonNull Path path, int version) {
@@ -88,33 +89,20 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
       int version,
       @NonNull List<BodyInterceptor> bodyInterceptors,
       @NonNull Collection<Path> ignoredPaths) {
-    this(path, srcType, version, bodyInterceptors, ignoredPaths, isMultiReleaseJar(path));
-  }
-
-  protected MultiReleaseJarAnalysisInputLocation(
-      @NonNull Path path,
-      @NonNull SourceType srcType,
-      int version,
-      @NonNull List<BodyInterceptor> bodyInterceptors,
-      @NonNull Collection<Path> ignoredPaths,
-      boolean isMultiRelease) {
     super(path, srcType);
     this.version = version;
     this.bodyInterceptors = bodyInterceptors;
-
-    if (!isMultiRelease) {
-      throw new IllegalArgumentException("The given path does not point to a multi release jar.");
-    }
 
     FileSystem fs;
     try {
       fs = fileSystemCache.get(path);
     } catch (ExecutionException e) {
-      throw new IllegalArgumentException("Could not open filesystemcache.", e);
+      throw new IllegalStateException("Could not open filesystemcache.", e);
     }
 
     final Path archiveRoot = fs.getPath("/");
-    Path versionedRoot = archiveRoot.getFileSystem().getPath("/META-INF/versions/");
+    FileSystem fileSystem = archiveRoot.getFileSystem();
+    Path versionedRoot = fileSystem.getPath("/META-INF/versions/");
 
     try (Stream<Path> list = Files.list(versionedRoot)) {
       list.map(dir -> dir.getFileName().toString())
@@ -124,18 +112,20 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
           .forEach(
               ver -> {
                 final Path versionRoot =
-                    archiveRoot.getFileSystem().getPath("/META-INF", "versions", ver.toString());
+                    fileSystem.getPath("/META-INF", "versions", ver.toString());
                 inputLocations.put(
                     ver,
-                    create(versionRoot, sourceType, bodyInterceptors, Collections.emptyList()));
+                    create(versionRoot, sourceType, bodyInterceptors, ignoredPaths));
               });
-
-      inputLocations.put(
-          DEFAULT_VERSION,
-          createAnalysisInputLocation(archiveRoot, srcType, getBodyInterceptors()));
     } catch (IOException e) {
       throw new IllegalStateException("Can not index the given file.", e);
     }
+
+    // add default path - as with a regular jar.
+    inputLocations.put(
+            DEFAULT_VERSION,
+            createAnalysisInputLocation(archiveRoot, srcType, getBodyInterceptors()));
+
   }
 
   protected AnalysisInputLocation createAnalysisInputLocation(
@@ -191,7 +181,7 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
     return version;
   }
 
-  public static boolean isMultiReleaseJar(Path path) {
+  public static boolean isMultiReleaseJar(@NonNull Path path) {
     try (FileInputStream inputStream = new FileInputStream(path.toFile());
         JarInputStream jarStream = new JarInputStream(inputStream)) {
       Manifest mf = jarStream.getManifest();

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
@@ -65,21 +65,6 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
 
   private final int version;
 
-  public static AnalysisInputLocation create(
-      @NonNull Path path,
-      @NonNull SourceType srcType,
-      int version,
-      List<BodyInterceptor> bodyInterceptors) {
-
-    if (isMultiReleaseJar(path)) {
-      return new MultiReleaseJarAnalysisInputLocation(
-          path, srcType, version, bodyInterceptors, true);
-    }
-
-    return create(
-        path, srcType, bodyInterceptors, Collections.singletonList(Paths.get("/META-INF")));
-  }
-
   public MultiReleaseJarAnalysisInputLocation(@NonNull Path path, int version) {
     this(path, SourceType.Application, version);
   }
@@ -94,7 +79,7 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
       @NonNull SourceType srcType,
       int version,
       @NonNull List<BodyInterceptor> bodyInterceptors) {
-    this(path, srcType, version, bodyInterceptors, isMultiReleaseJar(path));
+    this(path, srcType, version, bodyInterceptors, Collections.emptyList());
   }
 
   protected MultiReleaseJarAnalysisInputLocation(
@@ -102,6 +87,16 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
       @NonNull SourceType srcType,
       int version,
       @NonNull List<BodyInterceptor> bodyInterceptors,
+      @NonNull Collection<Path> ignoredPaths) {
+    this(path, srcType, version, bodyInterceptors, ignoredPaths, isMultiReleaseJar(path));
+  }
+
+  protected MultiReleaseJarAnalysisInputLocation(
+      @NonNull Path path,
+      @NonNull SourceType srcType,
+      int version,
+      @NonNull List<BodyInterceptor> bodyInterceptors,
+      @NonNull Collection<Path> ignoredPaths,
       boolean isMultiRelease) {
     super(path, srcType);
     this.version = version;

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
@@ -58,8 +58,6 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
   // "usual" Jar
   protected static final Integer DEFAULT_VERSION = 0;
 
-  @NonNull private final List<BodyInterceptor> bodyInterceptors;
-
   @NonNull
   protected final Map<Integer, AnalysisInputLocation> inputLocations = new LinkedHashMap<>();
 
@@ -89,9 +87,8 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
       int version,
       @NonNull List<BodyInterceptor> bodyInterceptors,
       @NonNull Collection<Path> ignoredPaths) {
-    super(path, srcType);
+    super(path, srcType, bodyInterceptors);
     this.version = version;
-    this.bodyInterceptors = bodyInterceptors;
 
     FileSystem fs;
     try {

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/MultiReleaseJarAnalysisInputLocation.java
@@ -36,6 +36,8 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import sootup.core.frontend.SootClassSource;
 import sootup.core.inputlocation.AnalysisInputLocation;
 import sootup.core.model.SourceType;
@@ -54,6 +56,9 @@ import sootup.java.core.JavaSootClassSource;
  */
 public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisInputLocation {
 
+  private static final @NonNull Logger logger =
+      LoggerFactory.getLogger(MultiReleaseJarAnalysisInputLocation.class);
+
   // ModularInputLocations exist since Java 9 -> in previous language levels its structured like a
   // "usual" Jar
   protected static final Integer DEFAULT_VERSION = 0;
@@ -61,7 +66,7 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
   @NonNull
   protected final Map<Integer, AnalysisInputLocation> inputLocations = new LinkedHashMap<>();
 
-  /** resembles the desired java version of the used view for this (MultiRelease) Jar  */
+  /** resembles the desired java version of the used view for this (MultiRelease) Jar */
   private final int version;
 
   public MultiReleaseJarAnalysisInputLocation(@NonNull Path path, int version) {
@@ -101,28 +106,29 @@ public class MultiReleaseJarAnalysisInputLocation extends ArchiveBasedAnalysisIn
     FileSystem fileSystem = archiveRoot.getFileSystem();
     Path versionedRoot = fileSystem.getPath("/META-INF/versions/");
 
-    try (Stream<Path> list = Files.list(versionedRoot)) {
-      list.map(dir -> dir.getFileName().toString())
-          .map(Integer::valueOf)
-          .filter(ver -> ver <= version)
-          .sorted(Comparator.reverseOrder())
-          .forEach(
-              ver -> {
-                final Path versionRoot =
-                    fileSystem.getPath("/META-INF", "versions", ver.toString());
-                inputLocations.put(
-                    ver,
-                    create(versionRoot, sourceType, bodyInterceptors, ignoredPaths));
-              });
-    } catch (IOException e) {
-      throw new IllegalStateException("Can not index the given file.", e);
+    if (Files.exists(versionedRoot)) {
+      try (Stream<Path> list = Files.list(versionedRoot)) {
+        list.map(dir -> dir.getFileName().toString())
+            .map(Integer::valueOf)
+            .filter(ver -> ver <= version)
+            .sorted(Comparator.reverseOrder())
+            .forEach(
+                ver -> {
+                  final Path versionRoot =
+                      fileSystem.getPath("/META-INF", "versions", ver.toString());
+                  inputLocations.put(
+                      ver, create(versionRoot, sourceType, bodyInterceptors, ignoredPaths));
+                });
+      } catch (IOException e) {
+        throw new IllegalStateException("Can not index the given file.", e);
+      }
+    } else {
+      logger.debug(path + " is not pointing to a multi release jar.");
     }
 
     // add default path - as with a regular jar.
     inputLocations.put(
-            DEFAULT_VERSION,
-            createAnalysisInputLocation(archiveRoot, srcType, getBodyInterceptors()));
-
+        DEFAULT_VERSION, createAnalysisInputLocation(archiveRoot, srcType, getBodyInterceptors()));
   }
 
   protected AnalysisInputLocation createAnalysisInputLocation(

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/PathBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/PathBasedAnalysisInputLocation.java
@@ -126,12 +126,10 @@ public abstract class PathBasedAnalysisInputLocation implements AnalysisInputLoc
       return new DirectoryBasedAnalysisInputLocation(path, srcType, bodyInterceptors, ignoredPaths);
     } else if (PathUtils.isArchive(path)) {
       if (PathUtils.hasExtension(path, FileType.JAR)) {
-        return new MultiReleaseJarAnalysisInputLocation(
-            path,
-            srcType,
-            MultiReleaseJarAnalysisInputLocation.DEFAULT_VERSION,
-            bodyInterceptors,
-            ignoredPaths);
+          return new ArchiveBasedAnalysisInputLocation(
+                  path,
+                  srcType,
+                  bodyInterceptors);
       } else if (PathUtils.hasExtension(path, FileType.WAR)) {
         try {
           return new WarArchiveAnalysisInputLocation(path, srcType, bodyInterceptors, ignoredPaths);

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/PathBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/PathBasedAnalysisInputLocation.java
@@ -126,10 +126,7 @@ public abstract class PathBasedAnalysisInputLocation implements AnalysisInputLoc
       return new DirectoryBasedAnalysisInputLocation(path, srcType, bodyInterceptors, ignoredPaths);
     } else if (PathUtils.isArchive(path)) {
       if (PathUtils.hasExtension(path, FileType.JAR)) {
-          return new ArchiveBasedAnalysisInputLocation(
-                  path,
-                  srcType,
-                  bodyInterceptors);
+        return new ArchiveBasedAnalysisInputLocation(path, srcType, bodyInterceptors);
       } else if (PathUtils.hasExtension(path, FileType.WAR)) {
         try {
           return new WarArchiveAnalysisInputLocation(path, srcType, bodyInterceptors, ignoredPaths);

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/PathBasedAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/PathBasedAnalysisInputLocation.java
@@ -126,7 +126,12 @@ public abstract class PathBasedAnalysisInputLocation implements AnalysisInputLoc
       return new DirectoryBasedAnalysisInputLocation(path, srcType, bodyInterceptors, ignoredPaths);
     } else if (PathUtils.isArchive(path)) {
       if (PathUtils.hasExtension(path, FileType.JAR)) {
-        return new ArchiveBasedAnalysisInputLocation(path, srcType, bodyInterceptors, ignoredPaths);
+        return new MultiReleaseJarAnalysisInputLocation(
+            path,
+            srcType,
+            MultiReleaseJarAnalysisInputLocation.DEFAULT_VERSION,
+            bodyInterceptors,
+            ignoredPaths);
       } else if (PathUtils.hasExtension(path, FileType.WAR)) {
         try {
           return new WarArchiveAnalysisInputLocation(path, srcType, bodyInterceptors, ignoredPaths);


### PR DESCRIPTION
- [x] ignore META-INF by default in ArchiveBasedanalysisInputLocation - reduce a lot of warnings 
- [x] don't fail - just log if non-multirelease is passed into a multirelease input location