### PR TITLE
A quick way to support Short constant

### DIFF
--- a/sootup.java.core/src/main/java/sootup/java/core/ConstantUtil.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/ConstantUtil.java
@@ -48,6 +48,9 @@ public class ConstantUtil {
     if (obj instanceof Integer) {
       return IntConstant.getInstance((Integer) obj);
     }
+    if (obj instanceof Short) {
+      return IntConstant.getInstance(((Short) obj).intValue());
+    }
     if (obj instanceof Long) {
       return LongConstant.getInstance((Long) obj);
     }


### PR DESCRIPTION
Currently ConstantUtil will throw IllegalArgumentException for annotation like below, where `fontHeightInPoints` is `java.lang.Short` 
```
@HeadFontStyle(fontHeightInPoints = 11, fontName = "Arial")
```