### PR TITLE
fix: Make type visitor pass ArrayType on case.

### DIFF
--- a/sootup.core/src/main/java/sootup/core/jimple/basic/LocalGenerator.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/basic/LocalGenerator.java
@@ -30,6 +30,7 @@ import org.jspecify.annotations.Nullable;
 import sootup.core.jimple.Jimple;
 import sootup.core.jimple.common.Local;
 import sootup.core.jimple.visitor.AbstractTypeVisitor;
+import sootup.core.types.ArrayType;
 import sootup.core.types.ClassType;
 import sootup.core.types.Type;
 
@@ -142,7 +143,7 @@ public class LocalGenerator {
     }
 
     @Override
-    public void caseArrayType() {
+    public void caseArrayType(@NonNull ArrayType arrayType) {
       result.append("r").append(tempRefLikeType++);
     }
 

--- a/sootup.core/src/main/java/sootup/core/jimple/visitor/AbstractTypeVisitor.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/visitor/AbstractTypeVisitor.java
@@ -71,7 +71,7 @@ public abstract class AbstractTypeVisitor implements TypeVisitor, Visitor {
   }
 
   @Override
-  public void caseArrayType() {
+  public void caseArrayType(@NonNull ArrayType arrayType) {
     defaultCaseType();
   }
 

--- a/sootup.core/src/main/java/sootup/core/jimple/visitor/TypeVisitor.java
+++ b/sootup.core/src/main/java/sootup/core/jimple/visitor/TypeVisitor.java
@@ -43,7 +43,7 @@ public interface TypeVisitor extends Visitor {
 
   void caseFloatType();
 
-  void caseArrayType();
+  void caseArrayType(@NonNull ArrayType arrayType);
 
   void caseClassType(@NonNull ClassType classType);
 

--- a/sootup.core/src/main/java/sootup/core/types/ArrayType.java
+++ b/sootup.core/src/main/java/sootup/core/types/ArrayType.java
@@ -98,7 +98,7 @@ public class ArrayType extends ReferenceType {
 
   @Override
   public <V extends TypeVisitor> V accept(@NonNull V v) {
-    v.caseArrayType();
+    v.caseArrayType(this);
     return v;
   }
 


### PR DESCRIPTION
Allow for type visitors to have access to the underlying `ArrayType` instance on `caseArrayType` case.

As requested in this question [here](https://github.com/soot-oss/SootUp/discussions/1199#discussion-8064956) it would be useful for accessing type information when building a method descriptor.