### PR TITLE
Remove duplicate predecessors correctly

### DIFF
--- a/sootup.core/src/main/java/sootup/core/graph/MutableBasicBlockImpl.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBasicBlockImpl.java
@@ -134,7 +134,7 @@ public class MutableBasicBlockImpl implements MutableBasicBlock {
 
   @Override
   public boolean removePredecessorBlock(@NonNull MutableBasicBlock b) {
-    return predecessorBlocks.remove(b);
+    return predecessorBlocks.removeIf(pred -> pred == b);
   }
 
   @Override


### PR DESCRIPTION
Sometimes it happens that a block is contained multiple times within the predecessor list of another block. When removing a block, only the first occurence of that block has previously been removed from the predecessor list of its sucessor. This fix removes all occurences.

This is probably a deeper issue during StmtGraph creation.