### PR TITLE
Handle Short type in ConstantUtil

### DIFF
--- a/sootup.java.core/src/main/java/sootup/java/core/ConstantUtil.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/ConstantUtil.java
@@ -48,6 +48,9 @@ public class ConstantUtil {
     if (obj instanceof Integer) {
       return IntConstant.getInstance((Integer) obj);
     }
+    if (obj instanceof Short) {
+      return IntConstant.getInstance((Short) obj);
+    }
     if (obj instanceof Long) {
       return LongConstant.getInstance((Long) obj);
     }


### PR DESCRIPTION
According to the document, a annotation value could be `Short`
https://asm.ow2.io/javadoc/org/objectweb/asm/tree/AnnotationNode.html

> The name value pairs of this annotation. Each name value pair is stored as two consecutive elements in the list. The name is a [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html), and the value may be a [Byte](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Byte.html), [Boolean](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Boolean.html), [Character](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Character.html), [Short](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Short.html), [Integer](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Integer.html), [Long](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Long.html), [Float](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Float.html), [Double](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Double.html), [String](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html) or [Type](https://asm.ow2.io/javadoc/org/objectweb/asm/Type.html), or a two elements String array (for enumeration values), an [AnnotationNode](https://asm.ow2.io/javadoc/org/objectweb/asm/tree/AnnotationNode.html), or a [List](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/List.html) of values of one of the preceding types. The list may be null if there is no name value pair.