### PR TITLE
Add getSourceFile to DexClassSource

### DIFF
--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/dexpler/DexClassSource.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/dexpler/DexClassSource.java
@@ -148,7 +148,7 @@ public class DexClassSource extends JavaSootClassSource {
    * @return The source file for this class as specified in the dex file.
    */
   public Optional<String> getSourceFile() {
-      return Optional.ofNullable(classInformation.classDefinition.getSourceFile());
+    return Optional.ofNullable(classInformation.classDefinition.getSourceFile());
   }
 
   @Override

--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/dexpler/DexClassSource.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/dexpler/DexClassSource.java
@@ -144,6 +144,9 @@ public class DexClassSource extends JavaSootClassSource {
     return NoPositionInformation.getInstance();
   }
 
+  /**
+   * @return The source file for this class as specified in the dex file.
+   */
   public Optional<String> getSourceFile() {
       return Optional.ofNullable(classInformation.classDefinition.getSourceFile());
   }

--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/dexpler/DexClassSource.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/dexpler/DexClassSource.java
@@ -144,6 +144,10 @@ public class DexClassSource extends JavaSootClassSource {
     return NoPositionInformation.getInstance();
   }
 
+  public Optional<String> getSourceFile() {
+      return Optional.ofNullable(classInformation.classDefinition.getSourceFile());
+  }
+
   @Override
   protected Iterable<AnnotationUsage> resolveAnnotations() {
     if (classInformation != null) {


### PR DESCRIPTION
Adds the method getSourceFile to DexClassSource. A dex file can include information about the original source file of a class. The org.jf.dexlib2 library already parses that information and is able to provide it through the method ClassDef#getSourceFile. The goal of this PR is to provide public access to that.