### PR TITLE
[Feature]: Default constructor for CpgCreator

### DIFF
--- a/sootup.codepropertygraph/src/main/java/sootup/codepropertygraph/cpg/CpgCreator.java
+++ b/sootup.codepropertygraph/src/main/java/sootup/codepropertygraph/cpg/CpgCreator.java
@@ -38,6 +38,16 @@ public class CpgCreator {
   private final DdgCreator ddgCreator;
 
   /**
+   * Default constructor that initializes all creators with their default implementations.
+   */
+  public CpgCreator() {
+    this.astCreator = new AstCreator();
+    this.cfgCreator = new CfgCreator();
+    this.cdgCreator = new CdgCreator();
+    this.ddgCreator = new DdgCreator();
+  }
+
+  /**
    * Constructs a CPG creator with the specified creators for AST, CFG, CDG, and DDG.
    *
    * @param astCreator the AST creator

--- a/sootup.codepropertygraph/src/main/java/sootup/codepropertygraph/cpg/CpgCreator.java
+++ b/sootup.codepropertygraph/src/main/java/sootup/codepropertygraph/cpg/CpgCreator.java
@@ -37,9 +37,7 @@ public class CpgCreator {
   private final CdgCreator cdgCreator;
   private final DdgCreator ddgCreator;
 
-  /**
-   * Default constructor that initializes all creators with their default implementations.
-   */
+  /** Default constructor that initializes all creators with their default implementations. */
   public CpgCreator() {
     this.astCreator = new AstCreator();
     this.cfgCreator = new CfgCreator();


### PR DESCRIPTION
```
This PR adds a no-argument (default) constructor to the CpgCreator class so it can be instantiated without explicitly providing AstCreator, CfgCreator, CdgCreator, and DdgCreator instances.
```