### PR TITLE
Fix: HashCode generation in JavaClassType

### DIFF
--- a/sootup.java.core/src/main/java/sootup/java/core/types/JavaClassType.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/types/JavaClassType.java
@@ -60,7 +60,7 @@ public class JavaClassType extends ClassType {
     }
     this.className = realClassName;
     this.packageName = packageName;
-    this.hashCode = Objects.hashCode(className, packageName);
+    this.hashCode = Objects.hashCode(realClassName, packageName);
   }
 
   @Override


### PR DESCRIPTION
JavaClassType uses the wrong className variable for it's hashCode generation. this.className is set to realClassName but the hashCode generation still uses the original className. This PR fixes that.