### PR TITLE
fix: correct ConstantBranchFolder logic

### DIFF
--- a/sootup.interceptors/src/main/java/sootup/interceptors/ConditionalBranchFolder.java
+++ b/sootup.interceptors/src/main/java/sootup/interceptors/ConditionalBranchFolder.java
@@ -52,35 +52,34 @@ public class ConditionalBranchFolder implements BodyInterceptor {
     final MutableControlFlowGraph controlFlowGraph = builder.getControlFlowGraph();
 
     for (Stmt stmt : Lists.newArrayList(controlFlowGraph.getNodes())) {
-      if (!(stmt instanceof JIfStmt)) {
+      if (!(stmt instanceof JIfStmt ifStmt)) {
         continue;
       }
 
-      JIfStmt ifStmt = (JIfStmt) stmt;
       // check for constant-valued conditions
       Constant evaluatedCondition = Evaluator.getConstantValueOf(ifStmt.getCondition());
 
       boolean removeTrueBranch;
       if (evaluatedCondition instanceof BooleanConstant) {
-        removeTrueBranch = evaluatedCondition == BooleanConstant.getTrue();
+        removeTrueBranch = evaluatedCondition == BooleanConstant.getFalse();
       } else if (evaluatedCondition instanceof IntConstant) {
         removeTrueBranch =
             IntConstant.getInstance(0).equalEqual(((IntConstant) evaluatedCondition))
-                == BooleanConstant.getFalse();
+                == BooleanConstant.getTrue();
       }
       /* TODO: check if the following Constant types are even possible in valid Jimple */
       else if (evaluatedCondition instanceof DoubleConstant) {
         removeTrueBranch =
             DoubleConstant.getInstance(0).equalEqual((DoubleConstant) evaluatedCondition)
-                == BooleanConstant.getFalse();
+                == BooleanConstant.getTrue();
       } else if (evaluatedCondition instanceof FloatConstant) {
         removeTrueBranch =
             FloatConstant.getInstance(0).equalEqual((FloatConstant) evaluatedCondition)
-                == BooleanConstant.getFalse();
+                == BooleanConstant.getTrue();
       } else if (evaluatedCondition instanceof LongConstant) {
         removeTrueBranch =
             LongConstant.getInstance(0).equalEqual((LongConstant) evaluatedCondition)
-                == BooleanConstant.getFalse();
+                == BooleanConstant.getTrue();
       } else {
         // not or not "easy" evaluatable
         continue;
@@ -182,7 +181,7 @@ public class ConditionalBranchFolder implements BodyInterceptor {
       if (predecessor.fallsThrough()) {
         if (predecessor instanceof JIfStmt) {
           final List<Stmt> predsSuccessors = graph.successors(predecessor);
-          if (predsSuccessors.size() > 0 && predsSuccessors.get(0) == stmt) {
+          if (!predsSuccessors.isEmpty() && predsSuccessors.get(0) == stmt) {
             // TODO: hint: possible problem occurs with partial removed targets as they change the
             // idx positions..
             amount--;

--- a/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/ConditionalBranchFolderTest.java
+++ b/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/ConditionalBranchFolderTest.java
@@ -75,10 +75,7 @@ public class ConditionalBranchFolderTest {
     new ConditionalBranchFolder().interceptBody(builder, new JavaView(Collections.emptyList()));
     Body processedBody = builder.build();
 
-    assertEquals(
-            Utils.bodyStmtsAsStrings(originalBody),
-            Utils.bodyStmtsAsStrings(processedBody)
-    );
+    assertEquals(Utils.bodyStmtsAsStrings(originalBody), Utils.bodyStmtsAsStrings(processedBody));
   }
 
   /**

--- a/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/ConditionalBranchFolderTest.java
+++ b/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/ConditionalBranchFolderTest.java
@@ -31,7 +31,6 @@ import sootup.java.core.views.JavaView;
  * @author Marcus Nachtigall
  */
 public class ConditionalBranchFolderTest {
-
   /**
    * Tests the correct deletion of an if-statement with a constant condition. Transforms from
    *
@@ -45,9 +44,11 @@ public class ConditionalBranchFolderTest {
   public void testUnconditionalBranching() {
     Body.BodyBuilder builder = createBodyBuilder(0);
     new ConditionalBranchFolder().interceptBody(builder, new JavaView(Collections.emptyList()));
+    Body processedBody = builder.build();
+
     assertEquals(
         Arrays.asList("a = \"str\"", "b = \"str\"", "return a"),
-        Utils.bodyStmtsAsStrings(builder.build()));
+        Utils.bodyStmtsAsStrings(processedBody));
   }
 
   /**
@@ -59,7 +60,6 @@ public class ConditionalBranchFolderTest {
   @Test
   public void testConditionalBranching() {
     Body.BodyBuilder builder = createBodyBuilder(1);
-    Body originalBody = builder.build();
     new ConditionalBranchFolder().interceptBody(builder, new JavaView(Collections.emptyList()));
     Body processedBody = builder.build();
 
@@ -75,7 +75,10 @@ public class ConditionalBranchFolderTest {
     new ConditionalBranchFolder().interceptBody(builder, new JavaView(Collections.emptyList()));
     Body processedBody = builder.build();
 
-    assertEquals(Utils.bodyStmtsAsStrings(originalBody), Utils.bodyStmtsAsStrings(processedBody));
+    assertEquals(
+            Utils.bodyStmtsAsStrings(originalBody),
+            Utils.bodyStmtsAsStrings(processedBody)
+    );
   }
 
   /**
@@ -140,8 +143,8 @@ public class ConditionalBranchFolderTest {
     bodyBuilder.setLocals(locals);
     controlFlowGraph.putEdge(strToA, strToB);
     controlFlowGraph.putEdge(strToB, ifStmt);
-    controlFlowGraph.putEdge(ifStmt, JIfStmt.FALSE_BRANCH_IDX, reta);
-    controlFlowGraph.putEdge(ifStmt, JIfStmt.TRUE_BRANCH_IDX, retb);
+    controlFlowGraph.putEdge(ifStmt, JIfStmt.TRUE_BRANCH_IDX, reta);
+    controlFlowGraph.putEdge(ifStmt, JIfStmt.FALSE_BRANCH_IDX, retb);
     controlFlowGraph.setStartingStmt(strToA);
     bodyBuilder.setMethodSignature(
         JavaIdentifierFactory.getInstance()


### PR DESCRIPTION
## What does this PR do?
The tests and the actual implementation where backwards, removing the true branch when the value is always true.

---

## Linked issue (if any)
- Fixes #1511 
  <!-- If this PR does not fully fix the issue, use "Refs #<issue-number>" -->

---

## Checklist

### Code style & guidelines
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments in the code
- [x] I provided meaningful tests for my proposed change
- [x] I updated documentation (if needed)

### Self-review
- [x] I performed a self-review of my code
- [x] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [x] My branch is up to date with `develop`

### Review
- [ ] CI checks are green
- [ ] I requested a review from a core contributor
