### PR TITLE
Removed BodyInterceptors from the callgraph tests

### DIFF
--- a/sootup.callgraph/src/test/java/sootup/callgraph/CallGraphTest.java
+++ b/sootup.callgraph/src/test/java/sootup/callgraph/CallGraphTest.java
@@ -18,6 +18,7 @@ import sootup.core.jimple.common.stmt.JAssignStmt;
 import sootup.core.jimple.common.stmt.Stmt;
 import sootup.core.model.SootClass;
 import sootup.core.model.SootMethod;
+import sootup.core.model.SourceType;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
 import sootup.java.bytecode.frontend.inputlocation.DefaultRuntimeAnalysisInputLocation;
@@ -36,12 +37,13 @@ public abstract class CallGraphTest {
 
   protected abstract AbstractCallGraphAlgorithm createAlgorithm(JavaView view);
 
-  // private static Map<String, JavaView> viewToClassPath = new HashMap<>();
-
   protected JavaView createViewForClassPath(String classPath) {
     List<AnalysisInputLocation> inputLocations = new ArrayList<>();
-    inputLocations.add(new DefaultRuntimeAnalysisInputLocation());
-    inputLocations.add(new JavaClassPathAnalysisInputLocation(classPath));
+    inputLocations.add(
+        new DefaultRuntimeAnalysisInputLocation(SourceType.Library, Collections.emptyList()));
+    inputLocations.add(
+        new JavaClassPathAnalysisInputLocation(
+            classPath, SourceType.Application, Collections.emptyList()));
 
     return new JavaView(inputLocations);
   }

--- a/sootup.callgraph/src/test/java/sootup/callgraph/ConcreteDispatchTest.java
+++ b/sootup.callgraph/src/test/java/sootup/callgraph/ConcreteDispatchTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import sootup.core.IdentifierFactory;
 import sootup.core.inputlocation.AnalysisInputLocation;
+import sootup.core.model.SourceType;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
 import sootup.java.bytecode.frontend.inputlocation.DefaultRuntimeAnalysisInputLocation;
@@ -31,8 +32,11 @@ public class ConcreteDispatchTest {
     List<AnalysisInputLocation> inputLocations = new ArrayList<>();
     inputLocations.add(
         new JavaClassPathAnalysisInputLocation(
-            "src/test/resources/callgraph/ConcreteDispatch/binary"));
-    inputLocations.add(new DefaultRuntimeAnalysisInputLocation());
+            "src/test/resources/callgraph/ConcreteDispatch/binary",
+            SourceType.Application,
+            Collections.emptyList()));
+    inputLocations.add(
+        new DefaultRuntimeAnalysisInputLocation(SourceType.Library, Collections.emptyList()));
     view = new JavaView(inputLocations);
   }
 


### PR DESCRIPTION
## What does this PR do?
Removes the bodyinterceptors from the callgraph tests to speedup the tests.
They are unecessary for the creation of call graphs.

---

## Linked issue (if any)
- Fixes #<issue-number>
  #1477 

---

## Checklist

### Code style & guidelines
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments in the code
- [x] I provided meaningful tests for my proposed change
- [x] I updated documentation (if needed)

### Self-review
- [x] I performed a self-review of my code
- [x] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [x] My branch is up to date with `develop`

### Review
- [x] CI checks are green
- [x] I requested a review from a core contributor
