### PR TITLE
Add additional Callgraph class inclusion filtering

### DIFF
--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -104,10 +104,24 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @return the complete constructed call graph starting from the entry methods.
    */
   @NonNull
+  final CallGraph constructCompleteCallGraph(List<MethodSignature> entryPoints) {
+    return constructCompleteCallGraph(entryPoints, null);
+  }
+
+  /**
+   * This method starts the construction of the call graph algorithm. It initializes the needed
+   * objects for the call graph generation and calls processWorkList method.
+   *
+   * @param entryPoints a list of method signatures that will be added to the work list in the call
+   *     graph generation.
+   * @param basePackageName the base package name of the source application. This is used to
+   *     filter out all classes from the call graph that do not contain this package name.
+   * @return the complete constructed call graph starting from the entry methods.
+   */
+  @NonNull
   final CallGraph constructCompleteCallGraph(
-      List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
-    applicationBasePackageName =
-        applicationBasePackageName != null ? applicationBasePackageName.toLowerCase() : null;
+      List<MethodSignature> entryPoints, @Nullable String basePackageName) {
+    basePackageName = basePackageName != null ? basePackageName.toLowerCase() : null;
 
     Deque<MethodSignature> workList = new ArrayDeque<>(entryPoints);
     Set<MethodSignature> processed = new HashSet<>();
@@ -118,7 +132,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     workList.addAll(clinits);
     MutableCallGraph cg = initializeCallGraph(entryPoints, clinits);
 
-    processWorkList(workList, processed, cg, applicationBasePackageName);
+    processWorkList(workList, processed, cg, basePackageName);
     return cg;
   }
 
@@ -167,12 +181,14 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    *     This list is filled in the execution with found call targets in the call graph algorithm.
    * @param processed the list of processed method to only process the method once.
    * @param cg the call graph object that is filled with the found methods and call edges.
+   * @param basePackageName the base package name of the source application. This is used to
+   *     filter out all classes from the call graph that do not contain this package name.
    */
   final void processWorkList(
       Deque<MethodSignature> workList,
       Set<MethodSignature> processed,
       MutableCallGraph cg,
-      @Nullable String applicationBasePackageName) {
+      @Nullable String basePackageName) {
     while (!workList.isEmpty()) {
       MethodSignature currentMethodSignature = workList.pop();
       // skip if already processed
@@ -185,8 +201,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
           view.getClass(currentMethodSignature.getDeclClassType()).orElse(null);
       if (currentClass == null
           || currentClass.isLibraryClass()
-          || (applicationBasePackageName != null
-              && !isClassPartOfApplication(currentClass, applicationBasePackageName))) {
+          || (basePackageName != null
+              && !isClassPartOfApplication(currentClass, basePackageName))) {
         continue;
       }
 
@@ -211,7 +227,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
 
                 // get all call targets of implicit edges in the method body
                 resolveAllImplicitCallsFromSourceMethod(
-                    currentMethod, cg, workList, applicationBasePackageName);
+                    currentMethod, cg, workList, basePackageName);
               });
 
       // set method as processed
@@ -222,13 +238,13 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     }
   }
 
-  private boolean isClassPartOfApplication(SootClass sootClass, String applicationBasePackageName) {
+  private boolean isClassPartOfApplication(SootClass sootClass, String basePackageName) {
     return isClassPartOfApplication(
-        sootClass.getClassSource().getClassType(), applicationBasePackageName);
+        sootClass.getClassSource().getClassType(), basePackageName);
   }
 
-  private boolean isClassPartOfApplication(ClassType classType, String applicationBasePackageName) {
-    return classType.getPackageName().toString().toLowerCase().contains(applicationBasePackageName);
+  private boolean isClassPartOfApplication(ClassType classType, String basePackageName) {
+    return classType.getPackageName().toString().toLowerCase().contains(basePackageName);
   }
 
   /**
@@ -375,15 +391,17 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param sourceMethod the inspected source method
    * @param cg new calls will be added to the call graph
    * @param workList new target methods will be added to the work list
+   * @param basePackageName the base package name of the source application. This is used to
+   *     filter out all classes from the call graph that do not contain this package name.
    */
   protected void resolveAllImplicitCallsFromSourceMethod(
       @NonNull SootMethod sourceMethod,
       @NonNull MutableCallGraph cg,
       @NonNull Deque<MethodSignature> workList,
-      @Nullable String applicationBasePackageName) {
+      @Nullable String basePackageName) {
     implicitStartRunCall(sourceMethod, cg, workList);
     // collect all static initializer calls
-    resolveAllStaticInitializerCalls(sourceMethod, cg, workList, applicationBasePackageName);
+    resolveAllStaticInitializerCalls(sourceMethod, cg, workList, basePackageName);
   }
 
   /**
@@ -392,12 +410,14 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param sourceMethod the inspected source method
    * @param cg clinit calls will be added to the call graph
    * @param workList found clinit methods will be added to the work list
+   * @param basePackageName the base package name of the source application. This is used to
+   *     filter out all classes from the call graph that do not contain this package name.
    */
   protected void resolveAllStaticInitializerCalls(
       @NonNull SootMethod sourceMethod,
       @NonNull MutableCallGraph cg,
       @NonNull Deque<MethodSignature> workList,
-      @Nullable String applicationBasePackageName) {
+      @Nullable String basePackageName) {
     MethodSignature sourceMethodSignature = sourceMethod.getSignature();
 
     InstantiateClassValueVisitor instantiateVisitor = new InstantiateClassValueVisitor();
@@ -411,7 +431,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
               if (invokableStmt.containsFieldRef()
                   && invokableStmt.getFieldRef() instanceof JStaticFieldRef) {
                 targetClass = invokableStmt.getFieldRef().getFieldSignature().getDeclClassType();
-                if (isClassPartOfApplication(targetClass, applicationBasePackageName)
+                if (isClassPartOfApplication(targetClass, basePackageName)
                     && !(targetClass
                             .getFullyQualifiedName()
                             .equals(
@@ -423,7 +443,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                       invokableStmt,
                       cg,
                       workList,
-                      applicationBasePackageName);
+                      basePackageName);
                 }
               }
               // static method
@@ -434,7 +454,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                   ClassType newTargetClass = expr.getMethodSignature().getDeclClassType();
                   // checks if the field points to the same clinit
                   if (!newTargetClass.equals(targetClass)) {
-                    if (isClassPartOfApplication(newTargetClass, applicationBasePackageName)
+                    if (isClassPartOfApplication(newTargetClass, basePackageName)
                         && !(newTargetClass
                                 .getFullyQualifiedName()
                                 .equals(
@@ -448,7 +468,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                           invokableStmt,
                           cg,
                           workList,
-                          applicationBasePackageName);
+                          basePackageName);
                     }
                   }
                 }
@@ -461,7 +481,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                   ClassType newTargetClass = instantiateVisitor.getResult();
                   // check if class type is the same as in the field which could be on the left op
                   if (newTargetClass != null && !newTargetClass.equals(targetClass)) {
-                    if (isClassPartOfApplication(newTargetClass, applicationBasePackageName)
+                    if (isClassPartOfApplication(newTargetClass, basePackageName)
                         && !(newTargetClass
                                 .getFullyQualifiedName()
                                 .equals(
@@ -475,7 +495,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                           invokableStmt,
                           cg,
                           workList,
-                          applicationBasePackageName);
+                          basePackageName);
                     }
                   }
                 }
@@ -493,6 +513,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param invokableStmt the statement causing the call
    * @param cg the call graph that will contain the found calls
    * @param workList the work list that will be updated with new target methods
+   * @param basePackageName the base package name of the source application. This is used to
+   *     filter out all classes from the call graph that do not contain this package name.
    */
   private void addStaticInitializerCalls(
       MethodSignature sourceSig,
@@ -500,7 +522,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
       InvokableStmt invokableStmt,
       MutableCallGraph cg,
       Deque<MethodSignature> workList,
-      String applicationBasePackageName) {
+      String basePackageName) {
     // static initializer call of class
     view.getMethod(view.getIdentifierFactory().getStaticInitializerSignature(targetClass))
         .ifPresent(
@@ -509,7 +531,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     // static initializer calls of all superclasses
     typeHierarchy
         .superClassesOf(targetClass)
-        .filter(classType -> isClassPartOfApplication(classType, applicationBasePackageName))
+        .filter(classType -> isClassPartOfApplication(classType, basePackageName))
         .map(
             classType ->
                 view.getMethod(

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -22,12 +22,8 @@ package sootup.callgraph;
  * #L%
  */
 
-import static sootup.core.jimple.basic.StmtPositionInfo.getNoStmtPositionInfo;
-
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sootup.callgraph.CallGraph.Call;
@@ -49,6 +45,12 @@ import sootup.core.typehierarchy.TypeHierarchy;
 import sootup.core.types.ClassType;
 import sootup.core.types.VoidType;
 import sootup.core.views.View;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static sootup.core.jimple.basic.StmtPositionInfo.getNoStmtPositionInfo;
 
 /**
  * The AbstractCallGraphAlgorithm class is the super class of all call graph algorithm. It provides
@@ -90,7 +92,11 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @return the complete constructed call graph starting from the entry methods.
    */
   @NonNull
-  final CallGraph constructCompleteCallGraph(List<MethodSignature> entryPoints) {
+  final CallGraph constructCompleteCallGraph(List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
+    applicationBasePackageName = applicationBasePackageName != null
+            ? applicationBasePackageName.toLowerCase()
+            : null;
+
     Deque<MethodSignature> workList = new ArrayDeque<>(entryPoints);
     Set<MethodSignature> processed = new HashSet<>();
 
@@ -100,7 +106,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     workList.addAll(clinits);
     MutableCallGraph cg = initializeCallGraph(entryPoints, clinits);
 
-    processWorkList(workList, processed, cg);
+    processWorkList(workList, processed, cg, applicationBasePackageName);
     return cg;
   }
 
@@ -150,8 +156,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param processed the list of processed method to only process the method once.
    * @param cg the call graph object that is filled with the found methods and call edges.
    */
-  final void processWorkList(
-      Deque<MethodSignature> workList, Set<MethodSignature> processed, MutableCallGraph cg) {
+  final void processWorkList(Deque<MethodSignature> workList, Set<MethodSignature> processed,
+                             MutableCallGraph cg, @Nullable String applicationBasePackageName) {
     while (!workList.isEmpty()) {
       MethodSignature currentMethodSignature = workList.pop();
       // skip if already processed
@@ -162,7 +168,9 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
       // skip if library class
       SootClass currentClass =
           view.getClass(currentMethodSignature.getDeclClassType()).orElse(null);
-      if (currentClass == null || currentClass.isLibraryClass()) {
+      if (currentClass == null
+          || currentClass.isLibraryClass()
+          || (applicationBasePackageName != null && !isClassPartOfApplication(currentClass, applicationBasePackageName))) {
         continue;
       }
 
@@ -195,6 +203,14 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
       // perform post-processing if needed
       postProcessingMethod(currentMethodSignature, workList, cg);
     }
+  }
+  private boolean isClassPartOfApplication(SootClass sootClass, String applicationBasePackageName) {
+      return sootClass.getClassSource()
+              .getClassType()
+              .getPackageName()
+              .toString()
+              .toLowerCase()
+              .contains(applicationBasePackageName);
   }
 
   /**
@@ -501,7 +517,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     // Step 1: Add edges from the new methods to other methods
     Deque<MethodSignature> workList = new ArrayDeque<>(newMethodSignatures);
     Set<MethodSignature> processed = new HashSet<>(oldCallGraph.getMethodSignatures());
-    processWorkList(workList, processed, updated);
+    processWorkList(workList, processed, updated, null);
 
     // Step 2: Add edges from old methods to methods overridden in the new class
     Stream<ClassType> superClasses = typeHierarchy.superClassesOf(classType);

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -84,6 +84,18 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   }
 
   /**
+   * Decide whether a call from <code>sourceMethod</code> to the <code>targetMethod</code> shall be
+   * added to the call graph. Default: accept everything. Subclasses can override this method to
+   * implement pruning.
+   *
+   * @param sourceMethod the source (caller) method
+   * @param targetMethod the target method of the call
+   */
+  protected boolean includeCallToTarget(@NonNull MethodSignature sourceMethod, @NonNull MethodSignature targetMethod) {
+    return true;
+  }
+
+  /**
    * This method starts the construction of the call graph algorithm. It initializes the needed
    * objects for the call graph generation and calls processWorkList method.
    *

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -22,6 +22,11 @@ package sootup.callgraph;
  * #L%
  */
 
+import static sootup.core.jimple.basic.StmtPositionInfo.getNoStmtPositionInfo;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -45,12 +50,6 @@ import sootup.core.typehierarchy.TypeHierarchy;
 import sootup.core.types.ClassType;
 import sootup.core.types.VoidType;
 import sootup.core.views.View;
-
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static sootup.core.jimple.basic.StmtPositionInfo.getNoStmtPositionInfo;
 
 /**
  * The AbstractCallGraphAlgorithm class is the super class of all call graph algorithm. It provides
@@ -91,7 +90,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param sourceMethod the source (caller) method
    * @param targetMethod the target method of the call
    */
-  protected boolean includeCallToTarget(@NonNull MethodSignature sourceMethod, @NonNull MethodSignature targetMethod) {
+  protected boolean includeCallToTarget(
+      @NonNull MethodSignature sourceMethod, @NonNull MethodSignature targetMethod) {
     return true;
   }
 
@@ -104,10 +104,10 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @return the complete constructed call graph starting from the entry methods.
    */
   @NonNull
-  final CallGraph constructCompleteCallGraph(List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
-    applicationBasePackageName = applicationBasePackageName != null
-            ? applicationBasePackageName.toLowerCase()
-            : null;
+  final CallGraph constructCompleteCallGraph(
+      List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
+    applicationBasePackageName =
+        applicationBasePackageName != null ? applicationBasePackageName.toLowerCase() : null;
 
     Deque<MethodSignature> workList = new ArrayDeque<>(entryPoints);
     Set<MethodSignature> processed = new HashSet<>();
@@ -168,8 +168,11 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param processed the list of processed method to only process the method once.
    * @param cg the call graph object that is filled with the found methods and call edges.
    */
-  final void processWorkList(Deque<MethodSignature> workList, Set<MethodSignature> processed,
-                             MutableCallGraph cg, @Nullable String applicationBasePackageName) {
+  final void processWorkList(
+      Deque<MethodSignature> workList,
+      Set<MethodSignature> processed,
+      MutableCallGraph cg,
+      @Nullable String applicationBasePackageName) {
     while (!workList.isEmpty()) {
       MethodSignature currentMethodSignature = workList.pop();
       // skip if already processed
@@ -182,7 +185,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
           view.getClass(currentMethodSignature.getDeclClassType()).orElse(null);
       if (currentClass == null
           || currentClass.isLibraryClass()
-          || (applicationBasePackageName != null && !isClassPartOfApplication(currentClass, applicationBasePackageName))) {
+          || (applicationBasePackageName != null
+              && !isClassPartOfApplication(currentClass, applicationBasePackageName))) {
         continue;
       }
 
@@ -206,7 +210,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                 resolveAllCallsFromSourceMethod(currentMethod, cg, workList);
 
                 // get all call targets of implicit edges in the method body
-                resolveAllImplicitCallsFromSourceMethod(currentMethod, cg, workList);
+                resolveAllImplicitCallsFromSourceMethod(
+                    currentMethod, cg, workList, applicationBasePackageName);
               });
 
       // set method as processed
@@ -216,13 +221,14 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
       postProcessingMethod(currentMethodSignature, workList, cg);
     }
   }
+
   private boolean isClassPartOfApplication(SootClass sootClass, String applicationBasePackageName) {
-      return sootClass.getClassSource()
-              .getClassType()
-              .getPackageName()
-              .toString()
-              .toLowerCase()
-              .contains(applicationBasePackageName);
+    return isClassPartOfApplication(
+        sootClass.getClassSource().getClassType(), applicationBasePackageName);
+  }
+
+  private boolean isClassPartOfApplication(ClassType classType, String applicationBasePackageName) {
+    return classType.getPackageName().toString().toLowerCase().contains(applicationBasePackageName);
   }
 
   /**
@@ -373,10 +379,11 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   protected void resolveAllImplicitCallsFromSourceMethod(
       @NonNull SootMethod sourceMethod,
       @NonNull MutableCallGraph cg,
-      @NonNull Deque<MethodSignature> workList) {
+      @NonNull Deque<MethodSignature> workList,
+      @Nullable String applicationBasePackageName) {
     implicitStartRunCall(sourceMethod, cg, workList);
     // collect all static initializer calls
-    resolveAllStaticInitializerCalls(sourceMethod, cg, workList);
+    resolveAllStaticInitializerCalls(sourceMethod, cg, workList, applicationBasePackageName);
   }
 
   /**
@@ -389,7 +396,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   protected void resolveAllStaticInitializerCalls(
       @NonNull SootMethod sourceMethod,
       @NonNull MutableCallGraph cg,
-      @NonNull Deque<MethodSignature> workList) {
+      @NonNull Deque<MethodSignature> workList,
+      @Nullable String applicationBasePackageName) {
     MethodSignature sourceMethodSignature = sourceMethod.getSignature();
 
     InstantiateClassValueVisitor instantiateVisitor = new InstantiateClassValueVisitor();
@@ -403,12 +411,19 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
               if (invokableStmt.containsFieldRef()
                   && invokableStmt.getFieldRef() instanceof JStaticFieldRef) {
                 targetClass = invokableStmt.getFieldRef().getFieldSignature().getDeclClassType();
-                if (!(targetClass
-                        .getFullyQualifiedName()
-                        .equals(sourceMethodSignature.getDeclClassType().getFullyQualifiedName())
-                    && sourceMethodSignature.getName().equals("<clinit>"))) {
+                if (isClassPartOfApplication(targetClass, applicationBasePackageName)
+                    && !(targetClass
+                            .getFullyQualifiedName()
+                            .equals(
+                                sourceMethodSignature.getDeclClassType().getFullyQualifiedName())
+                        && sourceMethodSignature.getName().equals("<clinit>"))) {
                   addStaticInitializerCalls(
-                      sourceMethodSignature, targetClass, invokableStmt, cg, workList);
+                      sourceMethodSignature,
+                      targetClass,
+                      invokableStmt,
+                      cg,
+                      workList,
+                      applicationBasePackageName);
                 }
               }
               // static method
@@ -419,13 +434,21 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                   ClassType newTargetClass = expr.getMethodSignature().getDeclClassType();
                   // checks if the field points to the same clinit
                   if (!newTargetClass.equals(targetClass)) {
-                    if (!(newTargetClass
-                            .getFullyQualifiedName()
-                            .equals(
-                                sourceMethodSignature.getDeclClassType().getFullyQualifiedName())
-                        && sourceMethodSignature.getName().equals("<clinit>"))) {
+                    if (isClassPartOfApplication(newTargetClass, applicationBasePackageName)
+                        && !(newTargetClass
+                                .getFullyQualifiedName()
+                                .equals(
+                                    sourceMethodSignature
+                                        .getDeclClassType()
+                                        .getFullyQualifiedName())
+                            && sourceMethodSignature.getName().equals("<clinit>"))) {
                       addStaticInitializerCalls(
-                          sourceMethodSignature, newTargetClass, invokableStmt, cg, workList);
+                          sourceMethodSignature,
+                          newTargetClass,
+                          invokableStmt,
+                          cg,
+                          workList,
+                          applicationBasePackageName);
                     }
                   }
                 }
@@ -438,13 +461,21 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
                   ClassType newTargetClass = instantiateVisitor.getResult();
                   // check if class type is the same as in the field which could be on the left op
                   if (newTargetClass != null && !newTargetClass.equals(targetClass)) {
-                    if (!(newTargetClass
-                            .getFullyQualifiedName()
-                            .equals(
-                                sourceMethodSignature.getDeclClassType().getFullyQualifiedName())
-                        && sourceMethodSignature.getName().equals("<clinit>"))) {
+                    if (isClassPartOfApplication(newTargetClass, applicationBasePackageName)
+                        && !(newTargetClass
+                                .getFullyQualifiedName()
+                                .equals(
+                                    sourceMethodSignature
+                                        .getDeclClassType()
+                                        .getFullyQualifiedName())
+                            && sourceMethodSignature.getName().equals("<clinit>"))) {
                       addStaticInitializerCalls(
-                          sourceMethodSignature, newTargetClass, invokableStmt, cg, workList);
+                          sourceMethodSignature,
+                          newTargetClass,
+                          invokableStmt,
+                          cg,
+                          workList,
+                          applicationBasePackageName);
                     }
                   }
                 }
@@ -468,7 +499,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
       ClassType targetClass,
       InvokableStmt invokableStmt,
       MutableCallGraph cg,
-      Deque<MethodSignature> workList) {
+      Deque<MethodSignature> workList,
+      String applicationBasePackageName) {
     // static initializer call of class
     view.getMethod(view.getIdentifierFactory().getStaticInitializerSignature(targetClass))
         .ifPresent(
@@ -477,6 +509,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
     // static initializer calls of all superclasses
     typeHierarchy
         .superClassesOf(targetClass)
+        .filter(classType -> isClassPartOfApplication(classType, applicationBasePackageName))
         .map(
             classType ->
                 view.getMethod(

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -84,18 +84,6 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   }
 
   /**
-   * Decide whether a call from <code>sourceMethod</code> to the <code>targetMethod</code> shall be
-   * added to the call graph. Default: accept everything. Subclasses can override this method to
-   * implement pruning.
-   *
-   * @param sourceMethod the source (caller) method
-   * @param targetMethod the target method of the call
-   */
-  protected boolean includeCallToTarget(@NonNull MethodSignature sourceMethod, @NonNull MethodSignature targetMethod) {
-    return true;
-  }
-
-  /**
    * This method starts the construction of the call graph algorithm. It initializes the needed
    * objects for the call graph generation and calls processWorkList method.
    *
@@ -297,13 +285,14 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
         .filter(Stmt::isInvokableStmt)
         .map(Stmt::asInvokableStmt)
         .forEach(
-            stmt -> {
-              Stream<MethodSignature> stream = includeCall(sourceMethod, stmt)
-                  ? resolveCall(sourceMethod, stmt)
-                  : Stream.empty();
-              stream.filter(targetMethod -> includeCallToTarget(sourceMethod.getSignature(), targetMethod))
-                  .forEach(targetMethod -> addCallToCG(sourceMethod.getSignature(), targetMethod, stmt, cg, workList));
-            });
+            stmt ->
+                (includeCall(sourceMethod, stmt)
+                        ? resolveCall(sourceMethod, stmt)
+                        : Stream.<MethodSignature>empty())
+                    .forEach(
+                        targetMethod ->
+                            addCallToCG(
+                                sourceMethod.getSignature(), targetMethod, stmt, cg, workList)));
   }
 
   /**

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -242,6 +242,10 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
       @NonNull InvokableStmt invokeStmt,
       @NonNull MutableCallGraph cg,
       @NonNull Deque<MethodSignature> workList) {
+    if (!includeCallToTarget(source, target)) {
+      return;
+    }
+
     if (!cg.containsMethod(source)) {
       cg.addMethod(source);
       workList.push(source);

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -114,8 +114,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    *
    * @param entryPoints a list of method signatures that will be added to the work list in the call
    *     graph generation.
-   * @param basePackageName the base package name of the source application. This is used to
-   *     filter out all classes from the call graph that do not contain this package name.
+   * @param basePackageName the base package name of the source application. This is used to filter
+   *     out all classes from the call graph that do not contain this package name.
    * @return the complete constructed call graph starting from the entry methods.
    */
   @NonNull
@@ -181,8 +181,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    *     This list is filled in the execution with found call targets in the call graph algorithm.
    * @param processed the list of processed method to only process the method once.
    * @param cg the call graph object that is filled with the found methods and call edges.
-   * @param basePackageName the base package name of the source application. This is used to
-   *     filter out all classes from the call graph that do not contain this package name.
+   * @param basePackageName the base package name of the source application. This is used to filter
+   *     out all classes from the call graph that do not contain this package name.
    */
   final void processWorkList(
       Deque<MethodSignature> workList,
@@ -239,8 +239,7 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   }
 
   private boolean isClassPartOfApplication(SootClass sootClass, String basePackageName) {
-    return isClassPartOfApplication(
-        sootClass.getClassSource().getClassType(), basePackageName);
+    return isClassPartOfApplication(sootClass.getClassSource().getClassType(), basePackageName);
   }
 
   private boolean isClassPartOfApplication(ClassType classType, String basePackageName) {
@@ -391,8 +390,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param sourceMethod the inspected source method
    * @param cg new calls will be added to the call graph
    * @param workList new target methods will be added to the work list
-   * @param basePackageName the base package name of the source application. This is used to
-   *     filter out all classes from the call graph that do not contain this package name.
+   * @param basePackageName the base package name of the source application. This is used to filter
+   *     out all classes from the call graph that do not contain this package name.
    */
   protected void resolveAllImplicitCallsFromSourceMethod(
       @NonNull SootMethod sourceMethod,
@@ -410,8 +409,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param sourceMethod the inspected source method
    * @param cg clinit calls will be added to the call graph
    * @param workList found clinit methods will be added to the work list
-   * @param basePackageName the base package name of the source application. This is used to
-   *     filter out all classes from the call graph that do not contain this package name.
+   * @param basePackageName the base package name of the source application. This is used to filter
+   *     out all classes from the call graph that do not contain this package name.
    */
   protected void resolveAllStaticInitializerCalls(
       @NonNull SootMethod sourceMethod,
@@ -513,8 +512,8 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
    * @param invokableStmt the statement causing the call
    * @param cg the call graph that will contain the found calls
    * @param workList the work list that will be updated with new target methods
-   * @param basePackageName the base package name of the source application. This is used to
-   *     filter out all classes from the call graph that do not contain this package name.
+   * @param basePackageName the base package name of the source application. This is used to filter
+   *     out all classes from the call graph that do not contain this package name.
    */
   private void addStaticInitializerCalls(
       MethodSignature sourceSig,

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -243,6 +243,9 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   }
 
   private boolean isClassPartOfApplication(ClassType classType, String basePackageName) {
+    if (basePackageName == null) {
+      return true;
+    }
     return classType.getPackageName().toString().toLowerCase().contains(basePackageName);
   }
 

--- a/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/AbstractCallGraphAlgorithm.java
@@ -84,6 +84,18 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
   }
 
   /**
+   * Decide whether a call from <code>sourceMethod</code> to the <code>targetMethod</code> shall be
+   * added to the call graph. Default: accept everything. Subclasses can override this method to
+   * implement pruning.
+   *
+   * @param sourceMethod the source (caller) method
+   * @param targetMethod the target method of the call
+   */
+  protected boolean includeCallToTarget(@NonNull MethodSignature sourceMethod, @NonNull MethodSignature targetMethod) {
+    return true;
+  }
+
+  /**
    * This method starts the construction of the call graph algorithm. It initializes the needed
    * objects for the call graph generation and calls processWorkList method.
    *
@@ -281,14 +293,13 @@ public abstract class AbstractCallGraphAlgorithm implements CallGraphAlgorithm {
         .filter(Stmt::isInvokableStmt)
         .map(Stmt::asInvokableStmt)
         .forEach(
-            stmt ->
-                (includeCall(sourceMethod, stmt)
-                        ? resolveCall(sourceMethod, stmt)
-                        : Stream.<MethodSignature>empty())
-                    .forEach(
-                        targetMethod ->
-                            addCallToCG(
-                                sourceMethod.getSignature(), targetMethod, stmt, cg, workList)));
+            stmt -> {
+              Stream<MethodSignature> stream = includeCall(sourceMethod, stmt)
+                  ? resolveCall(sourceMethod, stmt)
+                  : Stream.empty();
+              stream.filter(targetMethod -> includeCallToTarget(sourceMethod.getSignature(), targetMethod))
+                  .forEach(targetMethod -> addCallToCG(sourceMethod.getSignature(), targetMethod, stmt, cg, workList));
+            });
   }
 
   /**

--- a/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
@@ -22,12 +22,11 @@ package sootup.callgraph;
  * #L%
  */
 
+import java.util.List;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
-
-import java.util.List;
 
 /** The interface of a implemented call graph algorithms */
 public interface CallGraphAlgorithm {
@@ -50,7 +49,8 @@ public interface CallGraphAlgorithm {
    */
   @NonNull CallGraph initialize(@NonNull List<MethodSignature> entryPoints);
 
-  @NonNull CallGraph initialize(@NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName);
+  @NonNull CallGraph initialize(
+      @NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName);
 
   /**
    * Adds a class to the call graph. All methods will be set as entry points in the call graph

--- a/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
@@ -55,8 +55,8 @@ public interface CallGraphAlgorithm {
    *
    * @param entryPoints a list of entry points for the call graph algorithm. The algorithm starts at
    *     these methods and inspects all reachable methods.
-   * @param basePackageName the base package name of the source application. This is used to
-   *     filter out all classes from the call graph that do not contain this package name.
+   * @param basePackageName the base package name of the source application. This is used to filter
+   *     out all classes from the call graph that do not contain this package name.
    * @return a generated call graph with every entry point as starting point.
    */
   @NonNull CallGraph initialize(

--- a/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
@@ -49,8 +49,18 @@ public interface CallGraphAlgorithm {
    */
   @NonNull CallGraph initialize(@NonNull List<MethodSignature> entryPoints);
 
+  /**
+   * This method initializes and starts the call graph algorithm with given entry points. The entry
+   * points define the start methods in the call graph algorithm.
+   *
+   * @param entryPoints a list of entry points for the call graph algorithm. The algorithm starts at
+   *     these methods and inspects all reachable methods.
+   * @param basePackageName the base package name of the source application. This is used to
+   *     filter out all classes from the call graph that do not contain this package name.
+   * @return a generated call graph with every entry point as starting point.
+   */
   @NonNull CallGraph initialize(
-      @NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName);
+      @NonNull List<MethodSignature> entryPoints, @Nullable String basePackageName);
 
   /**
    * Adds a class to the call graph. All methods will be set as entry points in the call graph

--- a/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/CallGraphAlgorithm.java
@@ -22,10 +22,12 @@ package sootup.callgraph;
  * #L%
  */
 
-import java.util.List;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.types.ClassType;
+
+import java.util.List;
 
 /** The interface of a implemented call graph algorithms */
 public interface CallGraphAlgorithm {
@@ -47,6 +49,8 @@ public interface CallGraphAlgorithm {
    * @return a generated call graph with every entry point as starting point.
    */
   @NonNull CallGraph initialize(@NonNull List<MethodSignature> entryPoints);
+
+  @NonNull CallGraph initialize(@NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName);
 
   /**
    * Adds a class to the call graph. All methods will be set as entry points in the call graph

--- a/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
@@ -69,8 +69,8 @@ public class ClassHierarchyAnalysisAlgorithm extends AbstractCallGraphAlgorithm 
 
   @Override
   public @NonNull CallGraph initialize(
-      @NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
-    return constructCompleteCallGraph(entryPoints, applicationBasePackageName);
+      @NonNull List<MethodSignature> entryPoints, @Nullable String basePackageName) {
+    return constructCompleteCallGraph(entryPoints, basePackageName);
   }
 
   /**

--- a/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
@@ -22,10 +22,8 @@ package sootup.callgraph;
  * #L%
  */
 
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import sootup.core.jimple.common.expr.AbstractInvokeExpr;
 import sootup.core.jimple.common.expr.JDynamicInvokeExpr;
 import sootup.core.jimple.common.expr.JSpecialInvokeExpr;
@@ -37,6 +35,10 @@ import sootup.core.signatures.MethodSignature;
 import sootup.core.signatures.MethodSubSignature;
 import sootup.core.types.ClassType;
 import sootup.core.views.View;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class implements the Class Hierarchy Analysis call graph algorithm. In this algorithm, every
@@ -57,13 +59,19 @@ public class ClassHierarchyAnalysisAlgorithm extends AbstractCallGraphAlgorithm 
   @NonNull
   @Override
   public CallGraph initialize() {
-    return constructCompleteCallGraph(Collections.singletonList(findMainMethod()));
+    return constructCompleteCallGraph(Collections.singletonList(findMainMethod()), null);
   }
 
   @NonNull
   @Override
   public CallGraph initialize(@NonNull List<MethodSignature> entryPoints) {
-    return constructCompleteCallGraph(entryPoints);
+    return constructCompleteCallGraph(entryPoints, null);
+  }
+
+  @Override
+  public @NonNull CallGraph initialize(
+      @NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
+    return constructCompleteCallGraph(entryPoints, applicationBasePackageName);
   }
 
   /**

--- a/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/ClassHierarchyAnalysisAlgorithm.java
@@ -22,6 +22,9 @@ package sootup.callgraph;
  * #L%
  */
 
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import sootup.core.jimple.common.expr.AbstractInvokeExpr;
@@ -35,10 +38,6 @@ import sootup.core.signatures.MethodSignature;
 import sootup.core.signatures.MethodSubSignature;
 import sootup.core.types.ClassType;
 import sootup.core.views.View;
-
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class implements the Class Hierarchy Analysis call graph algorithm. In this algorithm, every
@@ -94,6 +93,10 @@ public class ClassHierarchyAnalysisAlgorithm extends AbstractCallGraphAlgorithm 
     AbstractInvokeExpr invokeExpr = optInvokeExpr.get();
     MethodSignature targetMethodSignature = invokeExpr.getMethodSignature();
     if ((invokeExpr instanceof JDynamicInvokeExpr)) {
+      return Stream.empty();
+    }
+
+    if (!includeCallToTarget(method.getSignature(), targetMethodSignature)) {
       return Stream.empty();
     }
 

--- a/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
@@ -23,6 +23,8 @@ package sootup.callgraph;
  */
 
 import com.google.common.collect.ArrayListMultimap;
+import java.util.*;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import sootup.callgraph.CallGraph.Call;
@@ -39,9 +41,6 @@ import sootup.core.signatures.MethodSignature;
 import sootup.core.signatures.MethodSubSignature;
 import sootup.core.types.ClassType;
 import sootup.core.views.View;
-
-import java.util.*;
-import java.util.stream.Stream;
 
 /**
  * This class implements the Rapid Type Analysis call graph algorithm. In this algorithm, every
@@ -92,7 +91,8 @@ public class RapidTypeAnalysisAlgorithm extends AbstractCallGraphAlgorithm {
 
   @NonNull
   @Override
-  public CallGraph initialize(@NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
+  public CallGraph initialize(
+      @NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
     // init helper data structures
     instantiatedClasses = new HashSet<>(instantiatedClasses);
     ignoredCalls = ArrayListMultimap.create();

--- a/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
@@ -92,12 +92,12 @@ public class RapidTypeAnalysisAlgorithm extends AbstractCallGraphAlgorithm {
   @NonNull
   @Override
   public CallGraph initialize(
-      @NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
+      @NonNull List<MethodSignature> entryPoints, @Nullable String basePackageName) {
     // init helper data structures
     instantiatedClasses = new HashSet<>(instantiatedClasses);
     ignoredCalls = ArrayListMultimap.create();
 
-    CallGraph cg = constructCompleteCallGraph(entryPoints, applicationBasePackageName);
+    CallGraph cg = constructCompleteCallGraph(entryPoints, basePackageName);
 
     // delete the data structures
     instantiatedClasses = Collections.emptySet();

--- a/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/RapidTypeAnalysisAlgorithm.java
@@ -23,9 +23,8 @@ package sootup.callgraph;
  */
 
 import com.google.common.collect.ArrayListMultimap;
-import java.util.*;
-import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import sootup.callgraph.CallGraph.Call;
 import sootup.core.jimple.common.expr.AbstractInvokeExpr;
 import sootup.core.jimple.common.expr.JDynamicInvokeExpr;
@@ -40,6 +39,9 @@ import sootup.core.signatures.MethodSignature;
 import sootup.core.signatures.MethodSubSignature;
 import sootup.core.types.ClassType;
 import sootup.core.views.View;
+
+import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * This class implements the Rapid Type Analysis call graph algorithm. In this algorithm, every
@@ -83,14 +85,19 @@ public class RapidTypeAnalysisAlgorithm extends AbstractCallGraphAlgorithm {
     return initialize(entryPoints);
   }
 
+  @Override
+  public @NonNull CallGraph initialize(@NonNull List<MethodSignature> entryPoints) {
+    return initialize(entryPoints, null);
+  }
+
   @NonNull
   @Override
-  public CallGraph initialize(@NonNull List<MethodSignature> entryPoints) {
+  public CallGraph initialize(@NonNull List<MethodSignature> entryPoints, @Nullable String applicationBasePackageName) {
     // init helper data structures
     instantiatedClasses = new HashSet<>(instantiatedClasses);
     ignoredCalls = ArrayListMultimap.create();
 
-    CallGraph cg = constructCompleteCallGraph(entryPoints);
+    CallGraph cg = constructCompleteCallGraph(entryPoints, applicationBasePackageName);
 
     // delete the data structures
     instantiatedClasses = Collections.emptySet();

--- a/sootup.java.core/src/main/java/sootup/java/core/types/JavaClassType.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/types/JavaClassType.java
@@ -60,7 +60,7 @@ public class JavaClassType extends ClassType {
     }
     this.className = realClassName;
     this.packageName = packageName;
-    this.hashCode = Objects.hashCode(className, packageName);
+    this.hashCode = Objects.hashCode(realClassName, packageName);
   }
 
   @Override


### PR DESCRIPTION
## What does this PR do?
<!-- Briefly describe the changes -->
Adds a nullable parameter called `basePackageName` to `CallGraphAlgorithm#initialize` that filters out all non-source classes from the graph (more accurately). Also adds `AbstractCallGraphAlgorithm#includeCallToTarget` for even more additional filtering.

The motivation behind this is that in Android projects often Android base API classes were included in the graph.

---

## Checklist

### Code style & guidelines
- [X] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [X] I added the necessary comments in the code
- [X] I provided meaningful tests for my proposed change - Not needed
- [X] I updated documentation (if needed)

### Self-review
- [X] I performed a self-review of my code
- [X] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [X] My branch is up to date with `develop`

### Review
- [ ] CI checks are green
- [ ] I requested a review from a core contributor
