### PR TITLE
Use correct pkg name for FileUtil

### DIFF
--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/conversion/FileUtil.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/conversion/FileUtil.java
@@ -1,4 +1,4 @@
-package sootup.java.bytecode.frontend;
+package sootup.java.bytecode.frontend.conversion;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/DownloadJarAnalysisInputLocation.java
+++ b/sootup.java.bytecode.frontend/src/main/java/sootup/java/bytecode/frontend/inputlocation/DownloadJarAnalysisInputLocation.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import sootup.core.model.SourceType;
 import sootup.core.transform.BodyInterceptor;
-import sootup.java.bytecode.frontend.FileUtil;
+import sootup.java.bytecode.frontend.conversion.FileUtil;
 
 /*-
  * #%L

--- a/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/inputlocation/DownloadJarInputLocationTest.java
+++ b/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/inputlocation/DownloadJarInputLocationTest.java
@@ -7,7 +7,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import sootup.core.model.SootMethod;
-import sootup.java.bytecode.frontend.FileUtil;
+import sootup.java.bytecode.frontend.conversion.FileUtil;
 import sootup.java.core.views.JavaView;
 
 public class DownloadJarInputLocationTest {


### PR DESCRIPTION
## What does this PR do?
fix pkg name for usages of FileUtil

---

## Linked issue (if any)

---

## Checklist

### Code style & guidelines
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments in the code
- [x] I provided meaningful tests for my proposed change
- [x] I updated documentation (if needed)

### Self-review
- [x] I performed a self-review of my code
- [x] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [x] My branch is up to date with `develop`

### Review
- [ ] CI checks are green
- [ ] I requested a review from a core contributor
