### PR TITLE
Make getClassSource deterministic in JavaView

### DIFF
--- a/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
@@ -22,9 +22,8 @@ package sootup.java.core.views;
  * #L%
  */
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 import sootup.core.cache.ClassCache;
@@ -137,15 +136,18 @@ public class JavaView extends AbstractView {
 
   @NonNull
   protected Optional<JavaSootClassSource> getClassSource(@NonNull ClassType type) {
-    return inputLocations.parallelStream()
-        .map(location -> location.getClassSource(type, this))
-        .filter(Optional::isPresent)
-        // like javas behaviour: if multiple matching Classes(ClassTypes) are found on the
-        // classpath the first is returned (see splitpackage)
-        .limit(1)
-        .map(Optional::get)
-        .map(classSource -> (JavaSootClassSource) classSource)
-        .findAny();
+    // Process inputLocations in parallel but preserve the "first-in-list" semantics by
+    // attaching indices and selecting the smallest index whose location produced a present
+    // Optional. This keeps full parallelism while returning the earliest-match by input order.
+    // Which actually matches the JVM behavior and is deterministic so nicer anyway.
+    return IntStream.range(0, inputLocations.size())
+        .parallel()
+        .mapToObj(
+            i -> new AbstractMap.SimpleEntry<>(i, inputLocations.get(i).getClassSource(type, this)))
+        .filter(e -> e.getValue().isPresent())
+        // pick the entry with the smallest original index
+        .min(Comparator.comparingInt(e -> e.getKey()))
+        .map(e -> (JavaSootClassSource) e.getValue().get());
   }
 
   @NonNull


### PR DESCRIPTION
## What does this PR do?
This PR makes the `getClassSource` method in `JavaView` deterministic while maintaining the performance benefits of parallel processing. 

Previously, the method used `parallelStream()` combined with `findAny()`, which could return a different `JavaSootClassSource` across different executions if multiple input locations contained the same class (a "race condition" in selection). 

The new implementation:
* Uses an `IntStream` to track the original index of each `inputLocation`.
* Processes lookups in parallel.
* Uses `.min()` based on the index to ensure that the source from the **earliest** input location is always selected.
* Aligns the library's behavior with standard JVM classpath resolution (first-match-wins) while remaining deterministic.

---

## Linked issue (if any)
- Fixes #
  ---

## Checklist

### Code style & guidelines
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments in the code
- [ ] I provided meaningful tests for my proposed change
- [ ] I updated documentation (if needed)

### Self-review
- [x] I performed a self-review of my code
- [x] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [x] My branch is up to date with `develop`

### Review
- [ ] CI checks are green
- [ ] I requested a review from a core contributor