### PR TITLE
Dex utils unified java class loading

### DIFF
--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/Util/DexUtil.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/Util/DexUtil.java
@@ -32,6 +32,7 @@ import sootup.core.signatures.PackageName;
 import sootup.core.types.*;
 import sootup.core.views.View;
 import sootup.java.core.AnnotationUsage;
+import sootup.java.core.JavaIdentifierFactory;
 import sootup.java.core.types.JavaClassType;
 
 public class DexUtil {
@@ -142,13 +143,8 @@ public class DexUtil {
       name = dottedClassName(name);
     }
     JavaClassType javaClassType;
-    int lastIndex = name.lastIndexOf(".");
-    lastIndex = (lastIndex == -1) ? 0 : lastIndex;
     try {
-      javaClassType =
-          new JavaClassType(
-              name.substring(name.lastIndexOf(".") + 1),
-              new PackageName(name.substring(0, lastIndex)));
+      javaClassType = JavaIdentifierFactory.getInstance().getClassType(name);
     } catch (Exception exception) {
       System.out.println("Exception when substring with className " + name);
       throw new RuntimeException();

--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/Util/DexUtil.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/Util/DexUtil.java
@@ -28,7 +28,6 @@ import org.jf.dexlib2.iface.AnnotationElement;
 import org.jf.dexlib2.iface.value.EncodedValue;
 import org.jspecify.annotations.NonNull;
 import sootup.apk.frontend.main.AndroidVersionInfo;
-import sootup.core.signatures.PackageName;
 import sootup.core.types.*;
 import sootup.core.views.View;
 import sootup.java.core.AnnotationUsage;


### PR DESCRIPTION
## What does this PR do?
This PR refactors `DexUtil` to use `JavaIdentifierFactory` for generating `JavaClassType` instances instead of manual string parsing and instantiation.

**Key Benefits:**
* **Optimization via Canonicalization:** By using the factory, we ensure that identical class names resolve to the same object instance. This reduces memory overhead by preventing duplicate class objects.
* **Support for Identity-based Lookups:** This change enables the safe use of `IdentityHashMap` or other identity-based structures for lookups when an `APKAnalysisInputLocation` is used alongside other input locations.
* **Improved Maintainability:** Removes error-prone manual substring logic for splitting class names and package names.

---

## Linked issue (if any)
- Fixes #
  ---

## Checklist

### Code style & guidelines
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments in the code
- [ ] I provided meaningful tests for my proposed change
- [ ] I updated documentation (if needed)

### Self-review
- [x] I performed a self-review of my code
- [ ] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [x] My branch is up to date with `develop`

### Review
- [ ] CI checks are green
- [ ] I requested a review from a core contributor