### PR TITLE
fix reusable workflow path

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     name: Tag, deploy to Maven Central and advance develop
     # Reusable workflow: secure-software-engineering/actions/release/README.md
-    uses: secure-software-engineering/actions/release/maven-release-publish/action.yml@d039e33678c4515ae4f9664e9fe9db33b84a6419 # develop
+    uses: secure-software-engineering/actions/.github/workflows/maven-release-publish.yml@486fdf8b917ee6ad71eb393010bd8b3952c208e6 # develop
     permissions:
       contents: write
     with:

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -1,0 +1,16 @@
+name: Release Schedule
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  schedule:
+    uses: secure-software-engineering/actions/.github/workflows/maven-release-schedule.yml@develop
+    with:
+      head_branch: develop
+      java_version: '17'
+      release_ready_age_days: '28'
+      stale_pr_age_days: '7'
+    secrets:
+      release_pat: ${{ secrets.AUTO_MERGE_PAT }}

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 9 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   schedule:
     uses: secure-software-engineering/actions/.github/workflows/maven-release-schedule.yml@develop

--- a/.github/workflows/release-title-sync.yml
+++ b/.github/workflows/release-title-sync.yml
@@ -20,6 +20,6 @@ jobs:
       startsWith(github.head_ref, 'release/prep-') &&
       github.event.pull_request.head.repo.full_name == github.repository
     # Reusable workflow: secure-software-engineering/actions/release/README.md
-    uses: secure-software-engineering/actions/release/maven-release-title-sync/action.yml@d039e33678c4515ae4f9664e9fe9db33b84a6419 # develop
+    uses: secure-software-engineering/actions/.github/workflows/maven-release-title-sync.yml@486fdf8b917ee6ad71eb393010bd8b3952c208e6 # develop
     secrets:
       release_pat: ${{ secrets.AUTO_MERGE_PAT }} # default GITHUB_TOKEN is blocked by branch protection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   prepare-release:
     name: Open release PR against develop
     # Reusable workflow: secure-software-engineering/actions/release/README.md
-    uses: secure-software-engineering/actions/release/maven-release-prepare/action.yml@d039e33678c4515ae4f9664e9fe9db33b84a6419 # develop
+    uses: secure-software-engineering/actions/.github/workflows/maven-release-prepare.yml@486fdf8b917ee6ad71eb393010bd8b3952c208e6 # develop
     with:
       release_type: ${{ inputs.release_type }}
       head_branch: develop


### PR DESCRIPTION
we created workflows, not composite actions: they need to live in the workflows path ;)
- create a release PR if there are changes, to remind/automate a regular release process 