### PR TITLE
Improve call graph edge lookup performance

### DIFF
--- a/sootup.callgraph/src/main/java/sootup/callgraph/GraphBasedCallGraph.java
+++ b/sootup.callgraph/src/main/java/sootup/callgraph/GraphBasedCallGraph.java
@@ -175,14 +175,7 @@ public class GraphBasedCallGraph implements MutableCallGraph {
 
   @Override
   public boolean containsCall(@NonNull Call call) {
-    EdgeIterator<Call> it = graph.edgeIterator();
-    while (it.hasNext()) {
-      it.next();
-      if (call.equals(it.getLabel())) {
-        return true;
-      }
-    }
-    return false;
+    return graph.findEdge(call) != null;
   }
 
   @Override


### PR DESCRIPTION
**What does this PR address? (Why)**

`GraphBasedCallGraph.containsCall` linearly scanned every edge. On a large CHA call graph, construction was still unfinished after 7h23m. Using Graph4J's indexed lookup, the same call graph completed in 24m24s.

**What are the main implementation details? (What, How)**

Replace the edge iteration with `graph.findEdge(call) != null`.

**Linked issue**

Closes #1678

**Validation**

- [x] `mvn -B -ntp -q clean test -pl sootup.callgraph -am -Dfmt.skip`
- [x] `mvn -B -ntp -q com.spotify.fmt:fmt-maven-plugin:check`
