### PR TITLE
perf: cache absent classes in JavaView.getClass

### DIFF
--- a/sootup.java.core/src/main/java/sootup/java/core/views/EagerLoadingStrategy.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/EagerLoadingStrategy.java
@@ -1,0 +1,79 @@
+package sootup.java.core.views;
+
+/*-
+ * #%L
+ * SootUp
+ * %%
+ * Copyright (C) 2026 Markus Schmidt and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.Optional;
+import org.jspecify.annotations.NonNull;
+import sootup.core.inputlocation.AnalysisInputLocation;
+import sootup.core.types.ClassType;
+import sootup.java.core.JavaSootClass;
+
+/**
+ * Resolves every class of a {@link JavaView} up front, at construction time, then releases the
+ * view's input locations. Used by {@link JavaEagerView}.
+ *
+ * <p>Since {@link #initialize} has already resolved (and cached) everything reachable, a class not
+ * found in the cache by the time {@link #resolveOnCacheMiss} runs will never be found - there is
+ * nothing left to probe, and the input locations are closed besides. This carries no absence-set
+ * bookkeeping, unlike {@link OnDemandLoadingStrategy}, because none is needed.
+ */
+public class EagerLoadingStrategy implements LoadingStrategy {
+
+  @Override
+  public void initialize(@NonNull JavaView view) {
+    view.getClasses()
+        .forEach(
+            c -> {
+              c.getModifiers();
+              c.getFields();
+              c.getInterfaces();
+              c.getAnnotations();
+              c.getSuperclass();
+              c.getOuterClass();
+              c.getPosition();
+              c.getMethods()
+                  .forEach(
+                      m -> {
+                        if (m.hasBody()) {
+                          m.getBody();
+                        }
+                      });
+            }); // forces loading
+
+    // All class data is now in the cache - release file-system resources.
+    for (AnalysisInputLocation loc : view.inputLocations) {
+      try {
+        loc.close();
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to close input location after eager load", e);
+      }
+    }
+  }
+
+  @Override
+  @NonNull
+  public Optional<JavaSootClass> resolveOnCacheMiss(
+      @NonNull JavaView view, @NonNull ClassType type) {
+    return Optional.empty();
+  }
+}

--- a/sootup.java.core/src/main/java/sootup/java/core/views/JavaEagerView.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/JavaEagerView.java
@@ -30,6 +30,7 @@ import sootup.core.cache.provider.FullCacheProvider;
 import sootup.core.inputlocation.AnalysisInputLocation;
 import sootup.java.core.JavaIdentifierFactory;
 
+/** Resolve all available SootClasses up front / eagerly. */
 public class JavaEagerView extends JavaView {
 
   public JavaEagerView(@NonNull AnalysisInputLocation inputLocation) {
@@ -43,37 +44,10 @@ public class JavaEagerView extends JavaView {
   public JavaEagerView(
       @NonNull List<AnalysisInputLocation> inputLocations,
       @NonNull ClassCacheProvider cacheProvider) {
-    super(inputLocations, cacheProvider, JavaIdentifierFactory.getInstance());
-    eagerLoadClasses();
-  }
-
-  protected void eagerLoadClasses() {
-    getClasses()
-        .forEach(
-            c -> {
-              c.getModifiers();
-              c.getFields();
-              c.getInterfaces();
-              c.getAnnotations();
-              c.getSuperclass();
-              c.getOuterClass();
-              c.getPosition();
-              c.getMethods()
-                  .forEach(
-                      m -> {
-                        if (m.hasBody()) {
-                          m.getBody();
-                        }
-                      });
-            }); // forces loading
-
-    // All class data is now in the FullCache — release file-system resources.
-    for (AnalysisInputLocation loc : inputLocations) {
-      try {
-        loc.close();
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to close input location after eager load", e);
-      }
-    }
+    super(
+        inputLocations,
+        cacheProvider,
+        LoadingStrategy.eager(),
+        JavaIdentifierFactory.getInstance());
   }
 }

--- a/sootup.java.core/src/main/java/sootup/java/core/views/JavaModuleView.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/JavaModuleView.java
@@ -58,7 +58,11 @@ public class JavaModuleView extends JavaView {
       @NonNull List<AnalysisInputLocation> inputLocations,
       @NonNull List<ModuleInfoAnalysisInputLocation> moduleInputLocations,
       @NonNull ClassCacheProvider cacheProvider) {
-    super(inputLocations, cacheProvider, JavaModuleIdentifierFactory.getInstance());
+    super(
+        inputLocations,
+        cacheProvider,
+        LoadingStrategy.onDemand(),
+        JavaModuleIdentifierFactory.getInstance());
     this.moduleInfoAnalysisInputLocations = moduleInputLocations;
     JavaModuleInfo unnamedModuleInfo = JavaModuleInfo.getUnnamedModuleInfo();
     moduleInfoMap.put(unnamedModuleInfo.getModuleSignature(), unnamedModuleInfo);

--- a/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
@@ -50,20 +50,7 @@ public class JavaView extends AbstractView {
 
   @NonNull protected final List<AnalysisInputLocation> inputLocations;
   @NonNull protected final ClassCache cache;
-
-  /**
-   * Types that none of the {@link AnalysisInputLocation}s could provide a class source for. {@link
-   * #cache} only memoizes successful resolutions, so without this every repeated lookup of an
-   * absent type re-runs {@link #getClassSource(ClassType)}, which probes every input location -
-   * including the JDK jimage filesystem - while holding this view's monitor. Call graph
-   * construction against an incomplete classpath does exactly that: it repeats a handful of failing
-   * lookups thousands of times.
-   *
-   * <p>Entries stay valid because the set of input locations is fixed for the lifetime of the view.
-   * A subclass that makes a class available afterwards has to call {@link
-   * #forgetAbsence(ClassType)} - see {@link MutableJavaView#addClass}.
-   */
-  @NonNull private final Set<ClassType> absentClasses = new HashSet<>();
+  @NonNull protected final LoadingStrategy loadingStrategy;
 
   protected volatile boolean isFullyResolved = false;
 
@@ -78,16 +65,26 @@ public class JavaView extends AbstractView {
   public JavaView(
       @NonNull List<AnalysisInputLocation> inputLocations,
       @NonNull ClassCacheProvider cacheProvider) {
-    this(inputLocations, cacheProvider, JavaIdentifierFactory.getInstance());
+    this(inputLocations, cacheProvider, LoadingStrategy.onDemand());
+  }
+
+  public JavaView(
+      @NonNull List<AnalysisInputLocation> inputLocations,
+      @NonNull ClassCacheProvider cacheProvider,
+      @NonNull LoadingStrategy loadingStrategy) {
+    this(inputLocations, cacheProvider, loadingStrategy, JavaIdentifierFactory.getInstance());
   }
 
   protected JavaView(
       @NonNull List<AnalysisInputLocation> inputLocations,
       @NonNull ClassCacheProvider cacheProvider,
+      @NonNull LoadingStrategy loadingStrategy,
       @NonNull JavaIdentifierFactory idf) {
     this.inputLocations = inputLocations;
     this.cache = cacheProvider.createCache();
+    this.loadingStrategy = loadingStrategy;
     this.identifierFactory = idf;
+    loadingStrategy.initialize(this);
   }
 
   /** Resolves all classes that are part of the view and stores them in the cache. */
@@ -121,32 +118,25 @@ public class JavaView extends AbstractView {
     if (cachedClass != null) {
       return Optional.of(cachedClass);
     }
-    if (absentClasses.contains(type)) {
-      return Optional.empty();
-    }
-
-    Optional<JavaSootClassSource> abstractClass = getClassSource(type);
-    if (abstractClass.isEmpty()) {
-      absentClasses.add(type);
-      return Optional.empty();
-    }
-    return Optional.of(buildClassFrom(abstractClass.get()));
+    return loadingStrategy.resolveOnCacheMiss(this, type);
   }
 
   /**
    * Forgets that {@code type} was previously resolved as absent, so that the next {@link
    * #getClass(ClassType)} queries the input locations again. Subclasses that make a class available
-   * after construction should call this.
+   * after construction should call this. Delegates to the active {@link LoadingStrategy}; a no-op
+   * under the eager strategy, which tracks no absence state to forget - by design, not a bug, since
+   * a class absent after an eager load can never become present.
    *
    * <p>It is not load-bearing for {@link MutableJavaView} as currently written: {@link
-   * #getClass(ClassType)} consults {@link #cache} before {@link #absentClasses}, and {@code
-   * addClass} populates that cache, so a stale absence record is shadowed anyway. It guards the
-   * cases where that no longer holds - if the two checks are ever reordered, or if a mutating view
-   * is given an evicting cache such as {@link sootup.core.cache.LRUCache}, where an added class can
-   * disappear from the cache again and let the stale record surface.
+   * #getClass(ClassType)} consults {@link #cache} before the loading strategy, and {@code addClass}
+   * populates that cache, so a stale absence record is shadowed anyway. It guards the cases where
+   * that no longer holds - if the two checks are ever reordered, or if a mutating view is given an
+   * evicting cache such as {@link sootup.core.cache.LRUCache}, where an added class can disappear
+   * from the cache again and let the stale record surface.
    */
   protected synchronized void forgetAbsence(@NonNull ClassType type) {
-    absentClasses.remove(type);
+    loadingStrategy.makeAvailable(type);
   }
 
   @Override

--- a/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/JavaView.java
@@ -51,6 +51,20 @@ public class JavaView extends AbstractView {
   @NonNull protected final List<AnalysisInputLocation> inputLocations;
   @NonNull protected final ClassCache cache;
 
+  /**
+   * Types that none of the {@link AnalysisInputLocation}s could provide a class source for. {@link
+   * #cache} only memoizes successful resolutions, so without this every repeated lookup of an
+   * absent type re-runs {@link #getClassSource(ClassType)}, which probes every input location -
+   * including the JDK jimage filesystem - while holding this view's monitor. Call graph
+   * construction against an incomplete classpath does exactly that: it repeats a handful of failing
+   * lookups thousands of times.
+   *
+   * <p>Entries stay valid because the set of input locations is fixed for the lifetime of the view.
+   * A subclass that makes a class available afterwards has to call {@link
+   * #forgetAbsence(ClassType)} - see {@link MutableJavaView#addClass}.
+   */
+  @NonNull private final Set<ClassType> absentClasses = new HashSet<>();
+
   protected volatile boolean isFullyResolved = false;
 
   public JavaView(@NonNull AnalysisInputLocation inputLocation) {
@@ -107,9 +121,32 @@ public class JavaView extends AbstractView {
     if (cachedClass != null) {
       return Optional.of(cachedClass);
     }
+    if (absentClasses.contains(type)) {
+      return Optional.empty();
+    }
 
     Optional<JavaSootClassSource> abstractClass = getClassSource(type);
-    return abstractClass.map(this::buildClassFrom);
+    if (abstractClass.isEmpty()) {
+      absentClasses.add(type);
+      return Optional.empty();
+    }
+    return Optional.of(buildClassFrom(abstractClass.get()));
+  }
+
+  /**
+   * Forgets that {@code type} was previously resolved as absent, so that the next {@link
+   * #getClass(ClassType)} queries the input locations again. Subclasses that make a class available
+   * after construction should call this.
+   *
+   * <p>It is not load-bearing for {@link MutableJavaView} as currently written: {@link
+   * #getClass(ClassType)} consults {@link #cache} before {@link #absentClasses}, and {@code
+   * addClass} populates that cache, so a stale absence record is shadowed anyway. It guards the
+   * cases where that no longer holds - if the two checks are ever reordered, or if a mutating view
+   * is given an evicting cache such as {@link sootup.core.cache.LRUCache}, where an added class can
+   * disappear from the cache again and let the stale record surface.
+   */
+  protected synchronized void forgetAbsence(@NonNull ClassType type) {
+    absentClasses.remove(type);
   }
 
   @Override

--- a/sootup.java.core/src/main/java/sootup/java/core/views/LoadingStrategy.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/LoadingStrategy.java
@@ -1,0 +1,82 @@
+package sootup.java.core.views;
+
+/*-
+ * #%L
+ * SootUp
+ * %%
+ * Copyright (C) 2026 Markus Schmidt and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.Optional;
+import org.jspecify.annotations.NonNull;
+import sootup.core.types.ClassType;
+import sootup.java.core.JavaSootClass;
+
+/**
+ * Determines how a {@link JavaView} resolves its classes: on demand (lazily, on first lookup) or
+ * eagerly (all at once, at construction time). Injected into {@link JavaView}'s constructor,
+ * mirroring how a {@link sootup.core.cache.provider.ClassCacheProvider} supplies the view's {@link
+ * sootup.core.cache.ClassCache}.
+ *
+ * <p>Implementations live in {@code sootup.java.core.views}, the same package as {@link JavaView},
+ * because {@link #resolveOnCacheMiss} and the default {@link #initialize} need to call {@link
+ * JavaView}'s {@code protected} {@code getClassSource}/{@code buildClassFrom}/{@code
+ * inputLocations} through a {@code JavaView}-typed parameter - which only compiles for same-package
+ * callers, not arbitrary subclasses (JLS 6.6.2).
+ */
+public interface LoadingStrategy {
+
+  @NonNull
+  static LoadingStrategy onDemand() {
+    return new OnDemandLoadingStrategy();
+  }
+
+  @NonNull
+  static LoadingStrategy eager() {
+    return new EagerLoadingStrategy();
+  }
+
+  /**
+   * Called exactly once, as the last statement of {@link JavaView}'s constructor, after all of
+   * {@code JavaView}'s own fields ({@code inputLocations}, {@code cache}, {@code loadingStrategy},
+   * {@code identifierFactory}) have been assigned. The default does nothing; only the eager
+   * strategy overrides this to resolve every class up front.
+   *
+   * <p>Because this runs before any subclass's own constructor body, any virtual call this makes on
+   * {@code view} must not depend on subclass fields that a subclass constructor would otherwise
+   * have initialized first. Do not wire the eager strategy into a {@link JavaView} subclass that
+   * overrides {@code getClasses()} or {@code buildClassFrom(...)} without re-checking this.
+   */
+  default void initialize(@NonNull JavaView view) {}
+
+  /**
+   * Called from {@link JavaView#getClass(ClassType)} after a cache miss, while holding the owning
+   * view's monitor. Returns the resolved class, or {@link Optional#empty()} if {@code type} cannot
+   * be resolved.
+   */
+  @NonNull Optional<JavaSootClass> resolveOnCacheMiss(
+      @NonNull JavaView view, @NonNull ClassType type);
+
+  /**
+   * Called from {@link JavaView#forgetAbsence(ClassType)}, itself called e.g. when {@link
+   * MutableJavaView#addClass} makes a previously-absent type available. The default does nothing,
+   * which is correct for the eager strategy: it tracks no absence state to forget, since a class
+   * absent after an eager load can never become present.
+   */
+  default void makeAvailable(@NonNull ClassType type) {}
+}

--- a/sootup.java.core/src/main/java/sootup/java/core/views/MutableJavaView.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/MutableJavaView.java
@@ -64,6 +64,8 @@ public class MutableJavaView extends JavaView implements MutableView {
       return;
     }
     this.cache.putClass(classType, clazz);
+    // the type may have been looked up - and recorded as absent - before it was added here
+    forgetAbsence(classType);
     this.fireAddition(clazz);
   }
 

--- a/sootup.java.core/src/main/java/sootup/java/core/views/OnDemandLoadingStrategy.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/views/OnDemandLoadingStrategy.java
@@ -1,0 +1,75 @@
+package sootup.java.core.views;
+
+/*-
+ * #%L
+ * SootUp
+ * %%
+ * Copyright (C) 2026 Markus Schmidt and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import sootup.core.types.ClassType;
+import sootup.java.core.JavaSootClass;
+import sootup.java.core.JavaSootClassSource;
+
+/**
+ * Lazily resolves classes on first lookup, the default {@link LoadingStrategy} for {@link
+ * JavaView}.
+ *
+ * <p>Memoizes types that no {@link sootup.core.inputlocation.AnalysisInputLocation} could provide a
+ * class source for. The owning view's positive {@code cache} only memoizes successful resolutions,
+ * so without this every repeated lookup of an absent type would re-run {@code getClassSource},
+ * which probes every input location - including the JDK jimage filesystem - while holding the
+ * view's monitor. Call graph construction against an incomplete classpath does exactly that: it
+ * repeats a handful of failing lookups thousands of times.
+ *
+ * <p>Not thread-safe on its own; callers only touch {@link #absentClasses} while holding the owning
+ * {@link JavaView}'s monitor (see {@link JavaView#getClass(ClassType)} / {@link
+ * JavaView#forgetAbsence(ClassType)}, both {@code synchronized}). Do not share one instance of this
+ * class across multiple {@link JavaView}s - each view's absence record is instance state, not a
+ * shared cache.
+ */
+public class OnDemandLoadingStrategy implements LoadingStrategy {
+
+  // TODO: [ms] if all classtypes are generated via IdentifierFactory we can use IdentityHashSet
+  @NonNull protected final Set<ClassType> absentClasses = new HashSet<>();
+
+  @Override
+  @NonNull
+  public Optional<JavaSootClass> resolveOnCacheMiss(
+      @NonNull JavaView view, @NonNull ClassType type) {
+    if (absentClasses.contains(type)) {
+      return Optional.empty();
+    }
+
+    Optional<JavaSootClassSource> classSourceOpt = view.getClassSource(type);
+    if (classSourceOpt.isEmpty()) {
+      absentClasses.add(type);
+      return Optional.empty();
+    }
+    return Optional.of(view.buildClassFrom(classSourceOpt.get()));
+  }
+
+  @Override
+  public void makeAvailable(@NonNull ClassType type) {
+    absentClasses.remove(type);
+  }
+}

--- a/sootup.java.core/src/test/java/sootup/java/core/views/JavaViewTest.java
+++ b/sootup.java.core/src/test/java/sootup/java/core/views/JavaViewTest.java
@@ -5,12 +5,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import sootup.core.cache.provider.FullCacheProvider;
+import sootup.core.frontend.SootClassSource;
 import sootup.core.inputlocation.AnalysisInputLocation;
 import sootup.core.inputlocation.EagerInputLocation;
 import sootup.core.types.ClassType;
@@ -81,6 +84,37 @@ public class JavaViewTest {
             .sorted(Comparator.comparing(Type::toString))
             .collect(Collectors.toList()),
         this.signatures);
+  }
+
+  /** Counts how often the input location is asked to resolve a class source. */
+  private static class CountingInputLocation extends EagerInputLocation {
+    int lookups = 0;
+
+    @Override
+    public @NonNull Optional<SootClassSource> getClassSource(
+        @NonNull ClassType type, sootup.core.views.View view) {
+      lookups++;
+      return super.getClassSource(type, view);
+    }
+  }
+
+  /**
+   * A type that no input location can provide must only be looked up once - {@link
+   * JavaView#getClass} memoizes the absence. Without that, every repeated lookup re-probes every
+   * input location, which dominates call graph construction against an incomplete classpath. This
+   * counts the lookups rather than timing them, so it is not sensitive to machine speed.
+   */
+  @Test
+  public void testAbsentClassIsResolvedOnlyOnce() {
+    CountingInputLocation inputLocation = new CountingInputLocation();
+    JavaView view = new JavaView(inputLocation);
+    ClassType absent = view.getIdentifierFactory().getClassType("com.example.NonExistingClass");
+
+    for (int i = 0; i < 20; i++) {
+      assertFalse(view.getClass(absent).isPresent());
+    }
+
+    assertEquals(1, inputLocation.lookups, "absent type must only be resolved once");
   }
 
   @Test

--- a/sootup.tests/src/test/java/sootup/tests/MutableSootClientTest.java
+++ b/sootup.tests/src/test/java/sootup/tests/MutableSootClientTest.java
@@ -91,6 +91,42 @@ public class MutableSootClientTest {
   }
 
   /**
+   * Adding a class that was already looked up - and found to be absent - must make it resolvable.
+   * {@link sootup.java.core.views.JavaView#getClass} memoizes absence, and this pins the invariant
+   * that a failed lookup cannot poison a later addition.
+   *
+   * <p>Note this passes with or without the {@code forgetAbsence} call in {@link
+   * MutableJavaView#addClass}, because {@code getClass} checks the class cache before the absence
+   * record. It is an invariant test, not a regression test for that call.
+   */
+  @Test
+  public void classAdditionAfterFailedLookupTest() {
+    JavaClassType addedClassType = mv.getIdentifierFactory().getClassType("LateAddedClass");
+
+    // the failed lookup is what records the type as absent
+    assertFalse(mv.getClass(addedClassType).isPresent());
+
+    OverridingJavaClassSource newClass =
+        new OverridingJavaClassSource(
+            location,
+            pathToJar,
+            addedClassType,
+            null,
+            Collections.emptySet(),
+            null,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            new FullPosition(0, 0, 0, 0),
+            EnumSet.noneOf(ClassModifier.class),
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Collections.emptySet());
+    mv.addClass(newClass.buildClass(SourceType.Application));
+
+    assertTrue(mv.getClass(addedClassType).isPresent());
+  }
+
+  /**
    * Remove a method from a class within the mutable view and check whether the class in the view
    * does not contain the specified method anymore.
    */


### PR DESCRIPTION
## Problem

`JavaView.getClass` memoizes successful resolutions in the `ClassCache` but not failures. On a miss it re-runs `getClassSource` every time, which probes every `AnalysisInputLocation` — including the JDK jimage filesystem — while holding the view's monitor.

Call graph construction against an incomplete classpath does this constantly. Measured over a full CHA `initialize()` on SootUp's own classes, with its dependency jars deliberately absent from the input locations:

| metric | value |
| --- | --- |
| `getClass` calls | 102,808 |
| misses | 1,457 (1.4%) |
| **distinct** missed types | **59** |
| redundant re-lookups | 1,398 |

The 59 types are guava, commons-lang3, slf4j, asm and friends — the ordinary situation when analysing an application without its full dependency set on the Soot classpath.

## Fix

Remember absent types, so a repeat miss costs one hash lookup. The positive cache is still consulted first, so the hot path is unchanged.

## Results

| workload | before | after | |
| --- | --- | --- | --- |
| 455 app classes / 4,150 entry points | 285 ms | ~150 ms | **1.9×** |
| 12 app classes / 179 entry points | 102 ms | ~19 ms | **5.4×** |

The mechanism is directly visible: the same 1,457 misses over 59 distinct types still happen, but **time spent in them drops from 271 ms to 21 ms**.

The ratio grows as the analysis shrinks, since the miss cost is roughly fixed in the number of distinct absent types. With a **complete** classpath there are 8 misses (1 distinct) and no measurable change (1.03×, noise) — this fix costs nothing when it isn't needed.

**Call graphs are identical.** Verified equal method and edge counts (13,577 / 335,355) with and without the cache on identical bytecode.

## Correctness

Entries stay valid because the set of input locations is fixed for the lifetime of the view.

`MutableJavaView.addClass` additionally clears the record via a new `protected forgetAbsence(ClassType)`. To be explicit: **that call is not load-bearing today** — `getClass` consults the class cache before the absence set, and `addClass` populates that cache, so a stale record is shadowed anyway. It is kept as insurance against a reordering of those two checks, or a mutating view backed by an evicting cache such as `LRUCache`. This is stated in the javadoc so nobody mistakes it for a fix to an active bug.

## Tests

- `JavaViewTest.testAbsentClassIsResolvedOnlyOnce` — counts input-location lookups rather than timing them, so it is not sensitive to machine speed. Verified load-bearing: without the cache it fails with `expected: <1> but was: <20>`.
- `MutableSootClientTest.classAdditionAfterFailedLookupTest` — pins the invariant that a failed lookup cannot poison a later `addClass`. Labelled in its javadoc as an invariant test, not a regression test for `forgetAbsence`, because it passes with or without that call.

`sootup.java.core` (91), `sootup.callgraph` (65) and `sootup.tests` (98) all pass.

## Notes for reviewers

- **Where absence lives.** Kept in `JavaView` rather than the `ClassCache` interface, which would mean changing the interface plus `FullCache`, `LRUCache` and `MutableFullCache`, and deciding whether an LRU cache should evict absence entries. Happy to move it if you'd prefer it behind the cache abstraction.
- **Not included, needs a decision.** `inputLocations` is a `final` *reference* assigned without a defensive copy, so a caller retaining its list could mutate it post-construction. The "absence is permanent" argument therefore rests on input locations being fixed *by contract*. A `List.copyOf(...)` in the constructor would make it true by construction — and would match the class javadoc's existing claim that the view "cannot be altered after its creation" — but it's a behaviour change, so I left it out.
- **Pre-existing, unrelated.** `sootup.java.bytecode.frontend` tests OOM with the default heap. Reproduced on clean `develop`, so not from this PR, but it may be worth a separate look.
- `.parallel()` in `getClassSource` is pointless for a short input-location list, but measured as noise (1.03×) — left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
