### PR TITLE
Fix: NullPointerException in exception analysis for new-array expressions with a primitive base type

### DIFF
--- a/sootup.java.core/src/main/java/sootup/java/core/exceptions/ExceptionInferExprVisitor.java
+++ b/sootup.java.core/src/main/java/sootup/java/core/exceptions/ExceptionInferExprVisitor.java
@@ -223,9 +223,11 @@ public class ExceptionInferExprVisitor extends AbstractExprVisitor {
 
   @Override
   public void caseNewArrayExpr(@NonNull JNewArrayExpr expr) {
-    if (expr.getBaseType() instanceof ReferenceType) {
-      result = new ExceptionInferResult(ExceptionInferResult.ErrorType.RESOLVE_CLASS_ERROR);
-    }
+    // only a reference base type has to be resolved, a primitive one cannot cause a LinkageError
+    result =
+        expr.getBaseType() instanceof ReferenceType
+            ? new ExceptionInferResult(ExceptionInferResult.ErrorType.RESOLVE_CLASS_ERROR)
+            : ExceptionInferResult.createEmptyException();
     Value count = expr.getSize();
     if (count instanceof Local) {
       result =

--- a/sootup.tests/src/test/java/sootup/tests/exceptions/StmtExceptionAnalyzerTest.java
+++ b/sootup.tests/src/test/java/sootup/tests/exceptions/StmtExceptionAnalyzerTest.java
@@ -6,7 +6,11 @@ import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import sootup.core.interceptor.BodyInterceptor;
+import sootup.core.jimple.Jimple;
+import sootup.core.jimple.basic.StmtPositionInfo;
+import sootup.core.jimple.common.Local;
 import sootup.core.jimple.common.Value;
+import sootup.core.jimple.common.constant.IntConstant;
 import sootup.core.jimple.common.expr.*;
 import sootup.core.jimple.common.ref.JArrayRef;
 import sootup.core.jimple.common.ref.JInstanceFieldRef;
@@ -20,7 +24,9 @@ import sootup.core.model.SourceType;
 import sootup.core.signatures.MethodSignature;
 import sootup.core.typehierarchy.TypeHierarchy;
 import sootup.core.typehierarchy.ViewTypeHierarchy;
+import sootup.core.types.ArrayType;
 import sootup.core.types.ClassType;
+import sootup.core.types.PrimitiveType;
 import sootup.interceptors.*;
 import sootup.java.bytecode.frontend.inputlocation.ClassFileBasedAnalysisInputLocation;
 import sootup.java.bytecode.frontend.inputlocation.DefaultRuntimeAnalysisInputLocation;
@@ -300,5 +306,68 @@ public class StmtExceptionAnalyzerTest {
                     result.getExceptions().contains(ExceptionInferResult.ExceptionType.THROWABLE));
               }
             });
+  }
+
+  @Test
+  public void testNewArrayExprWithPrimitiveBaseType() {
+    StmtPositionInfo noPositionInfo = StmtPositionInfo.getNoStmtPositionInfo();
+    Local arr = Jimple.newLocal("arr", new ArrayType(PrimitiveType.getInt(), 1));
+    Local size = Jimple.newLocal("size", PrimitiveType.getInt());
+    Set<ClassType> defaultExceptions =
+        new HashSet<>(
+            Arrays.asList(
+                ExceptionInferResult.ErrorType.VM_ERROR,
+                ExceptionInferResult.ErrorType.THREAD_DEATH));
+
+    // arr = new int[4]: a non-negative constant size cannot throw a NegativeArraySizeException and
+    // a primitive base type needs no class resolution, so only the default result remains.
+    Stmt constantSize =
+        Jimple.newAssignStmt(
+            arr,
+            new JNewArrayExpr(PrimitiveType.getInt(), IntConstant.getInstance(4), factory),
+            noPositionInfo);
+    Assertions.assertEquals(
+        defaultExceptions, exceptionAnalyser.mightThrowImplicitly(constantSize).getExceptions());
+
+    // arr = new int[-1]: a negative constant size always throws a NegativeArraySizeException.
+    Set<ClassType> withNegativeArraySize = new HashSet<>(defaultExceptions);
+    withNegativeArraySize.add(ExceptionInferResult.ExceptionType.NEGATIVE_ARRAY_SIZE_EXCEPTION);
+    Stmt negativeConstantSize =
+        Jimple.newAssignStmt(
+            arr,
+            new JNewArrayExpr(PrimitiveType.getInt(), IntConstant.getInstance(-1), factory),
+            noPositionInfo);
+    Assertions.assertEquals(
+        withNegativeArraySize,
+        exceptionAnalyser.mightThrowImplicitly(negativeConstantSize).getExceptions());
+
+    // arr = new int[size]: an unknown size might be negative.
+    Stmt localSize =
+        Jimple.newAssignStmt(
+            arr, new JNewArrayExpr(PrimitiveType.getInt(), size, factory), noPositionInfo);
+    Assertions.assertEquals(
+        withNegativeArraySize, exceptionAnalyser.mightThrowImplicitly(localSize).getExceptions());
+  }
+
+  @Test
+  public void testNewArrayExprWithReferenceBaseType() {
+    StmtPositionInfo noPositionInfo = StmtPositionInfo.getNoStmtPositionInfo();
+    ClassType integerType = factory.getClassType("java.lang.Integer");
+    Local arr = Jimple.newLocal("arr", new ArrayType(integerType, 1));
+    Set<ClassType> expected =
+        new HashSet<>(
+            Arrays.asList(
+                ExceptionInferResult.ErrorType.VM_ERROR,
+                ExceptionInferResult.ErrorType.THREAD_DEATH,
+                ExceptionInferResult.ErrorType.RESOLVE_CLASS_ERROR));
+
+    // arr = new Integer[4]: a reference base type has to be resolved.
+    Stmt constantSize =
+        Jimple.newAssignStmt(
+            arr,
+            new JNewArrayExpr(integerType, IntConstant.getInstance(4), factory),
+            noPositionInfo);
+    Assertions.assertEquals(
+        expected, exceptionAnalyser.mightThrowImplicitly(constantSize).getExceptions());
   }
 }


### PR DESCRIPTION
**What does this PR address? (Why)**

`StmtExceptionAnalyzer::mightThrow()` throws a `NullPointerException` for any array creation with a primitive base type, e.g. `int[] arr = new int[4];`.

`ExceptionInferExprVisitor.caseNewArrayExpr()` only initialized its `result` field when the array's base type is a `ReferenceType`:

```java
public void caseNewArrayExpr(@NonNull JNewArrayExpr expr) {
  if (expr.getBaseType() instanceof ReferenceType) {
    result = new ExceptionInferResult(ErrorType.RESOLVE_CLASS_ERROR);   // <-- only here
  }
  Value count = expr.getSize();
  if (count instanceof Local) {
    result = result.addException(NEGATIVE_ARRAY_SIZE_EXCEPTION, hierarchy);
  } else if (count instanceof IntConstant) { ... }
}
```

Unlike `ExceptionInferStmtVisitor`, this visitor's constructor never seeds `result`, and every other `case*` method assigns it unconditionally. So for a primitive base type `result` stays `null`, which gives two failure modes:

* **Constant size** (`new int[4]`) — `getResult()` returns `null` and the NPE surfaces one frame later in `ExceptionInferResult.addExceptions` on `newResult.exceptions`:

  ```
  java.lang.NullPointerException: Cannot read field "exceptions" because "newResult" is null
      at sootup.java.core.exceptions.ExceptionInferResult.addExceptions(ExceptionInferResult.java:94)
      at sootup.java.core.exceptions.ExceptionInferStmtVisitor.caseAssignStmt(ExceptionInferStmtVisitor.java:85)
      at sootup.java.core.exceptions.StmtExceptionAnalyzer.mightThrowImplicitly(StmtExceptionAnalyzer.java:112)
  ```

* **Variable size** (`new int[a]`) — NPE directly inside `caseNewArrayExpr` on `result.addException`.

The existing `StmtExceptionAnalyzerTest` did not catch this because its test resource only creates reference-typed arrays (`new Integer[5]`).

**What are the main implementation details? (What, How)**

`result` is now assigned unconditionally, so the branch below can never dereference `null`:

```java
result =
    expr.getBaseType() instanceof ReferenceType
        ? new ExceptionInferResult(ExceptionInferResult.ErrorType.RESOLVE_CLASS_ERROR)
        : ExceptionInferResult.createEmptyException();
```

The `createEmptyException()` for the primitive case should be correct, because there can't be a RESOLVE_CLASS_ERROR for a primitive type.

`caseNewMultiArrayExpr` needs no equivalent change, because the base type of `JNewMultiArrayExpr` is always an `ArrayType` and thus a `ReferenceType`.

Two test methods were added to `StmtExceptionAnalyzerTest`, built directly from the Jimple API so no new binary test resource is needed:

| statement | expected exceptions |
| --- | --- |
| `new int[4]` | `VirtualMachineError`, `ThreadDeath` |
| `new int[-1]` | + `NegativeArraySizeException` |
| `new int[size]` | + `NegativeArraySizeException` |
| `new Integer[4]` | + `LinkageError` (regression guard) |

Both fail with the NPE above before the fix and pass after it. The three pre-existing tests in the class are unaffected.

**Linked issue (if any)**

None. I did not find an existing issue for this.

**Checklist**

*Code style & guidelines*
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments in the code
- [x] I provided meaningful tests for my proposed change
- [ ] I updated documentation (if needed) — not needed, no public API or documented behaviour changes

*Self-review*
- [x] I performed a self-review of my code
- [x] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally (`sootup.tests` `StmtExceptionAnalyzerTest`: 5/5 pass; full `sootup.java.core` suite passes)
- [x] My branch is up to date with `develop`

*Review*
- [ ] CI checks are green
- [ ] I requested a review from a core contributor
