### PR TITLE
Unreachable block parsing bug in the ApkFrontend

### DIFF
--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
@@ -378,10 +378,138 @@ public class DexBody {
     if (!currentList.isEmpty()) {
       listList.add(currentList);
     }
+    removeUnreachableBlocks(listList, branchingStmtListMap);
     graph.initializeWith(listList, branchingStmtListMap, traps);
     DexMethodSource dexMethodSource =
         new DexMethodSource(locals, methodSignature, graph, method, bodyInterceptors, view);
     return dexMethodSource.makeSootMethod();
+  }
+
+  private void removeUnreachableBlocks(
+      List<List<Stmt>> blocks, Map<BranchingStmt, List<Stmt>> successorMap) {
+    if (blocks.isEmpty()) {
+      return;
+    }
+
+    Map<Stmt, Integer> blockOfHead = new IdentityHashMap<>();
+    for (int i = 0; i < blocks.size(); i++) {
+      blockOfHead.put(blocks.get(i).get(0), i);
+    }
+
+    boolean[] reachable = new boolean[blocks.size()];
+    Deque<Integer> worklist = new ArrayDeque<>();
+    reachable[0] = true;
+    worklist.add(0);
+    // A handler is entered by an exceptional edge from the Stmts its Trap covers, so it becomes
+    // reachable as soon as any block of that range is.
+    boolean foundHandler = true;
+    while (foundHandler) {
+      followEdges(blocks, successorMap, blockOfHead, reachable, worklist);
+      foundHandler = false;
+      for (Trap trap : traps) {
+        Integer handler = blockOfHead.get(trap.getHandlerStmt());
+        if (handler != null
+            && !reachable[handler]
+            && isRangeReachable(trap, blockOfHead, reachable, blocks.size())) {
+          markReachable(handler, reachable, worklist);
+          foundHandler = true;
+        }
+      }
+    }
+
+    Set<Stmt> removedStmts = Collections.newSetFromMap(new IdentityHashMap<>());
+    for (int i = 0; i < blocks.size(); i++) {
+      if (!reachable[i]) {
+        removedStmts.addAll(blocks.get(i));
+      }
+    }
+    if (removedStmts.isEmpty()) {
+      return;
+    }
+
+    List<Trap> keptTraps = new ArrayList<>(traps.size());
+    for (Trap trap : traps) {
+      if (removedStmts.contains(trap.getBeginStmt())
+          || removedStmts.contains(trap.getHandlerStmt())) {
+        // nothing is left of the covered range, or of the handler that would catch for it
+        continue;
+      }
+      Stmt end = trap.getEndStmt();
+      if (removedStmts.contains(end)) {
+        // the end is exclusive, so with the Stmt behind the range gone, the range grows up to the
+        // next block that stayed; a range that would reach the end of the body cannot be expressed
+        end = null;
+        Integer endIndex = blockOfHead.get(trap.getEndStmt());
+        for (int i = endIndex == null ? blocks.size() : endIndex + 1; i < blocks.size(); i++) {
+          if (reachable[i]) {
+            end = blocks.get(i).get(0);
+            break;
+          }
+        }
+        if (end == null || end == trap.getBeginStmt()) {
+          continue;
+        }
+      }
+      keptTraps.add(
+          end == trap.getEndStmt()
+              ? trap
+              : Jimple.newTrap(
+                  trap.getExceptionType(), trap.getBeginStmt(), end, trap.getHandlerStmt()));
+    }
+    traps.clear();
+    traps.addAll(keptTraps);
+
+    successorMap.keySet().removeIf(removedStmts::contains);
+    stmtList.removeIf(removedStmts::contains);
+    blocks.removeIf(block -> removedStmts.contains(block.get(0)));
+  }
+
+  private static void followEdges(
+      List<List<Stmt>> blocks,
+      Map<BranchingStmt, List<Stmt>> successorMap,
+      Map<Stmt, Integer> blockOfHead,
+      boolean[] reachable,
+      Deque<Integer> worklist) {
+    while (!worklist.isEmpty()) {
+      int index = worklist.poll();
+      List<Stmt> block = blocks.get(index);
+      Stmt tail = block.get(block.size() - 1);
+      if (tail.fallsThrough()) {
+        markReachable(index + 1 < blocks.size() ? index + 1 : null, reachable, worklist);
+      }
+      if (tail.branches()) {
+        List<Stmt> targets = successorMap.get((BranchingStmt) tail);
+        if (targets != null) {
+          for (Stmt target : targets) {
+            markReachable(blockOfHead.get(target), reachable, worklist);
+          }
+        }
+      }
+    }
+  }
+
+  private static boolean isRangeReachable(
+      Trap trap, Map<Stmt, Integer> blockOfHead, boolean[] reachable, int blockCount) {
+    Integer begin = blockOfHead.get(trap.getBeginStmt());
+    if (begin == null) {
+      return false;
+    }
+    Integer end = blockOfHead.get(trap.getEndStmt());
+    // end is exclusive.
+    for (int i = begin, last = end == null ? blockCount : end; i < last; i++) {
+      if (reachable[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void markReachable(
+      @Nullable Integer blockIndex, boolean[] reachable, Deque<Integer> worklist) {
+    if (blockIndex != null && !reachable[blockIndex]) {
+      reachable[blockIndex] = true;
+      worklist.add(blockIndex);
+    }
   }
 
   // Just a conversion code from LinkedListMultimap<BranchingStmt, List<Stmt>> to Map<BranchingStmt,

--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
@@ -34,6 +34,7 @@ import org.jf.dexlib2.immutable.debug.ImmutableLineNumber;
 import org.jf.dexlib2.immutable.debug.ImmutableRestartLocal;
 import org.jf.dexlib2.immutable.debug.ImmutableStartLocal;
 import org.jf.dexlib2.util.MethodUtil;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sootup.apk.frontend.Util.DexUtil;
@@ -327,9 +328,6 @@ public class DexBody {
     jimplify();
     // All the statements are converted, it is time to create a mutable statement graph
     MutableBlockControlFlowGraph graph = new MutableBlockControlFlowGraph();
-    // If the Nop Statements are not removed, graph.initializeWith throws a runtime exception
-    // It is only for the case where there is a JNop Statement after the return statement. Crazy
-    // android code :(
     MethodSignature methodSignature =
         view.getIdentifierFactory()
             .getMethodSignature(
@@ -337,10 +335,6 @@ public class DexBody {
                 method.getName(),
                 DexUtil.toSootType(method.getReturnType(), 0),
                 parameterTypes);
-    while (stmtList.get(stmtList.size() - 1) instanceof JNopStmt) {
-      stmtList.remove(stmtList.size() - 1);
-    }
-    //    stmtList.removeIf(JNopStmt.class::isInstance);
     Map<BranchingStmt, List<Stmt>> branchingStmtListMap = convertMultimap(branchingMap);
     Set<Stmt> blockBegin = new HashSet<>();
     Set<Stmt> blockEnd = new HashSet<>();
@@ -356,6 +350,14 @@ public class DexBody {
           blockBegin.add(trap.getEndStmt());
           blockBegin.add(trap.getHandlerStmt());
         });
+
+    // A Stmt that does not fall through - a return, a throw, a goto - ends its block. Whatever dex
+    // placed behind it is only reachable by a jump and must not be chained onto it.
+    for (Stmt stmt : stmtList) {
+      if (!stmt.fallsThrough()) {
+        blockEnd.add(stmt);
+      }
+    }
 
     List<List<Stmt>> listList = new ArrayList<>();
     List<Stmt> currentList = new ArrayList<>();

--- a/sootup.apk.frontend/src/test/java/sootup/apk/frontend/DexBodyEdgeCaseTest.java
+++ b/sootup.apk.frontend/src/test/java/sootup/apk/frontend/DexBodyEdgeCaseTest.java
@@ -1,0 +1,571 @@
+package sootup.apk.frontend;
+
+/*-
+ * #%L
+ * SootUp
+ * %%
+ * Copyright (C) 2022 - 2024 Kadiray Karakaya, Markus Schmidt, Jonas Klauke, Stefan Schott, Palaniappan Muthuraman, Marcus Hüwe and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.jf.dexlib2.AccessFlags;
+import org.jf.dexlib2.Opcode;
+import org.jf.dexlib2.Opcodes;
+import org.jf.dexlib2.builder.MethodImplementationBuilder;
+import org.jf.dexlib2.builder.SwitchLabelElement;
+import org.jf.dexlib2.builder.instruction.BuilderArrayPayload;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction10t;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction10x;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction11n;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction11x;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction21t;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction22c;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction31t;
+import org.jf.dexlib2.builder.instruction.BuilderPackedSwitchPayload;
+import org.jf.dexlib2.builder.instruction.BuilderSparseSwitchPayload;
+import org.jf.dexlib2.immutable.ImmutableClassDef;
+import org.jf.dexlib2.immutable.ImmutableDexFile;
+import org.jf.dexlib2.immutable.ImmutableMethod;
+import org.jf.dexlib2.immutable.reference.ImmutableTypeReference;
+import org.jf.dexlib2.writer.pool.DexPool;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import sootup.apk.frontend.main.AndroidVersionInfo;
+import sootup.core.jimple.common.Trap;
+import sootup.core.model.Body;
+import sootup.core.util.printer.BriefStmtPrinter;
+import sootup.java.core.views.JavaView;
+
+/**
+ * Converts hand-built dex bodies that are legal for Dalvik but unusual for a Java compiler, to pin
+ * down what the frontend makes of them.
+ *
+ * <p>The bodies are assembled with dexlib2 and written to a bare {@code .dex} file instead of an
+ * APK, which the frontend accepts and which keeps every case readable next to its assertion. Most
+ * of them are about {@code nop}: dex has that instruction and needs it to pad the payload of a
+ * switch or of fill-array-data to a four byte boundary, so nops turn up in ordinary compiler output
+ * and anywhere an obfuscator wants to move code around.
+ *
+ * <p>The line the frontend draws is reachability, not the opcode: a Stmt that flow can arrive at
+ * stays in the Jimple, a nop as much as anything else, and only what nothing reaches is dropped -
+ * it cannot be expressed in a ControlFlowGraph that {@code Body.build} accepts. So each case below
+ * says both which Stmts survive and, where it matters, that a reachable nop is among them.
+ */
+public class DexBodyEdgeCaseTest {
+
+  @TempDir static Path tempDir;
+
+  /**
+   * Builds a dex holding one static {@code void run()} with the given instructions and loads it.
+   */
+  private static Body convert(
+      String name, int registerCount, Consumer<MethodImplementationBuilder> instructions) {
+    String descriptor = "Ldex/" + name + ";";
+    MethodImplementationBuilder builder = new MethodImplementationBuilder(registerCount);
+    instructions.accept(builder);
+    ImmutableMethod method =
+        new ImmutableMethod(
+            descriptor,
+            "run",
+            ImmutableList.of(),
+            "V",
+            AccessFlags.PUBLIC.getValue() | AccessFlags.STATIC.getValue(),
+            null,
+            null,
+            builder.getMethodImplementation());
+    ImmutableClassDef classDef =
+        new ImmutableClassDef(
+            descriptor,
+            AccessFlags.PUBLIC.getValue(),
+            "Ljava/lang/Object;",
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(method),
+            null);
+
+    Path dex = tempDir.resolve(name + ".dex");
+    try {
+      DexPool.writeTo(dex.toString(), new ImmutableDexFile(Opcodes.forApi(15), List.of(classDef)));
+    } catch (IOException e) {
+      throw new IllegalStateException("could not write " + dex, e);
+    }
+
+    JavaView view =
+        new JavaView(
+            List.of(
+                new ApkAnalysisInputLocation(
+                    dex,
+                    new AndroidVersionInfo(dex, ""),
+                    DexBodyInterceptors.Default.bodyInterceptors())));
+    return view.getMethod(
+            view.getIdentifierFactory()
+                .getMethodSignature(
+                    view.getIdentifierFactory().getClassType("dex." + name),
+                    "run",
+                    "void",
+                    List.of()))
+        .get()
+        .getBody();
+  }
+
+  private static List<String> stmtsOf(Body body) {
+    return body.getStmts().stream().map(Object::toString).collect(Collectors.toList());
+  }
+
+  private static List<Trap> trapsOf(Body body) {
+    return new BriefStmtPrinter(body.getControlFlowGraph()).getTraps();
+  }
+
+  /**
+   * {@code goto} does not fall through, so a nop behind it heads a block that nothing branches to.
+   * This is the shape that obfuscated APKs are full of.
+   */
+  @Test
+  public void unreachableNopBehindGotoIsDropped() {
+    Body body =
+        convert(
+            "NopBehindGoto",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("goto", "return"), stmtsOf(body));
+  }
+
+  /**
+   * A nop between a {@code return} and a branch target. The return does not fall through, so the
+   * nop is dead, but it sits at the tail of the return's block and carries the fallthrough edge
+   * into the target's block. A {@code NopEliminator} run over the built graph cannot repair this
+   * one: {@code removeNode(nop, keepFlow=true)} leaves the block's successor edge in place, and it
+   * then hangs off the {@code return}.
+   */
+  @Test
+  public void unreachableNopBehindReturnIsDropped() {
+    Body body =
+        convert(
+            "NopBehindReturn",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("$u0 = 0", "if $u0 == 0", "return", "return"), stmtsOf(body));
+  }
+
+  /** A nop that is a jump target is reached by that jump, so it stays and keeps the jump. */
+  @Test
+  public void nopThatIsABranchTargetIsKept() {
+    Body body =
+        convert(
+            "BranchToANop",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 1));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(
+        List.of("$u0 = 0", "if $u0 == 0", "return", "nop", "nop", "$u0 = 1", "return"),
+        stmtsOf(body));
+    // the second successor of the if is the branch target, which is the first of the two nops
+    assertEquals(
+        "nop", body.getControlFlowGraph().successors(body.getStmts().get(1)).get(1).toString());
+  }
+
+  /** The same for a backwards jump, which makes the nop the head of the loop body. */
+  @Test
+  public void nopThatIsABackwardsBranchTargetIsKept() {
+    Body body =
+        convert(
+            "BackwardsBranchToANop",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("$u0 = 0", "nop", "if $u0 == 0", "return"), stmtsOf(body));
+    assertEquals(
+        "nop", body.getControlFlowGraph().successors(body.getStmts().get(2)).get(1).toString());
+  }
+
+  /** Nops behind the last Stmt of the body - the only case the frontend used to handle. */
+  @Test
+  public void trailingNopsAreDropped() {
+    Body body =
+        convert(
+            "TrailingNops",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+            });
+
+    assertEquals(List.of("return"), stmtsOf(body));
+  }
+
+  /** A nop as the entry instruction is the reachable Stmt of the method, and stays its head. */
+  @Test
+  public void leadingNopIsKeptAsTheStartingStmt() {
+    Body body =
+        convert(
+            "LeadingNop",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("nop", "$u0 = 0", "return"), stmtsOf(body));
+    assertEquals("nop", body.getControlFlowGraph().getStartingStmt().toString());
+  }
+
+  /** A body that is nothing but nops and a return: every one of them is on the path. */
+  @Test
+  public void bodyOfOnlyNopsIsKept() {
+    Body body =
+        convert(
+            "OnlyNops",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("nop", "nop", "nop", "return"), stmtsOf(body));
+  }
+
+  /**
+   * The reason nops exist in compiler output: a packed-switch payload has to start on a four byte
+   * boundary, so dx/d8 pads with a nop whenever the preceding code has an odd number of code units.
+   */
+  @Test
+  public void alignmentNopBeforeAPackedSwitchPayload() {
+    Body body =
+        convert(
+            "PackedSwitchPadding",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 1));
+              b.addInstruction(
+                  new BuilderInstruction31t(Opcode.PACKED_SWITCH, 0, b.getLabel("payload")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("case0");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("case1");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("payload");
+              b.addInstruction(
+                  new BuilderPackedSwitchPayload(
+                      0, List.of(b.getLabel("case0"), b.getLabel("case1"))));
+            });
+
+    assertEquals(
+        List.of(
+            "$u0 = 1",
+            "switch($u0) {     case 0:     case 1:     default:  }",
+            "return",
+            "return",
+            "return"),
+        stmtsOf(body));
+  }
+
+  /** The same for a sparse-switch payload. */
+  @Test
+  public void alignmentNopBeforeASparseSwitchPayload() {
+    Body body =
+        convert(
+            "SparseSwitchPadding",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 1));
+              b.addInstruction(
+                  new BuilderInstruction31t(Opcode.SPARSE_SWITCH, 0, b.getLabel("payload")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("case7");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("payload");
+              b.addInstruction(
+                  new BuilderSparseSwitchPayload(
+                      List.of(new SwitchLabelElement(7, b.getLabel("case7")))));
+            });
+
+    assertTrue(
+        stmtsOf(body).stream().anyMatch(stmt -> stmt.startsWith("switch")),
+        stmtsOf(body).toString());
+    assertTrue(stmtsOf(body).stream().noneMatch("nop"::equals), stmtsOf(body).toString());
+  }
+
+  /**
+   * fill-array-data with an empty payload is the one place where the frontend itself emits a nop.
+   */
+  @Test
+  public void emptyArrayPayload() {
+    Body body =
+        convert(
+            "EmptyArrayPayload",
+            2,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(
+                  new BuilderInstruction22c(
+                      Opcode.NEW_ARRAY, 1, 0, new ImmutableTypeReference("[I")));
+              b.addInstruction(
+                  new BuilderInstruction31t(Opcode.FILL_ARRAY_DATA, 1, b.getLabel("data")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("data");
+              b.addInstruction(new BuilderArrayPayload(4, List.of()));
+            });
+
+    assertEquals(List.of("$u0 = 0", "$u1 = newarray (int)[$u0]", "nop", "return"), stmtsOf(body));
+  }
+
+  /** A try block that starts on a nop keeps that nop, and with it its range. */
+  @Test
+  public void trapBeginningOnANopKeepsItsRange() {
+    Body body =
+        convert(
+            "TrapBeginsOnNop",
+            2,
+            b -> {
+              b.addLabel("try");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addLabel("end");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("handler");
+              b.addInstruction(new BuilderInstruction11x(Opcode.MOVE_EXCEPTION, 1));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addCatch(
+                  new ImmutableTypeReference("Ljava/lang/Exception;"),
+                  b.getLabel("try"),
+                  b.getLabel("end"),
+                  b.getLabel("handler"));
+            });
+
+    assertEquals(
+        List.of("nop", "$u0 = 0", "return", "$u1 := @caughtexception", "return"), stmtsOf(body));
+    assertEquals(1, trapsOf(body).size());
+    assertEquals("nop", trapsOf(body).get(0).getBeginStmt().toString());
+  }
+
+  /** A try block whose whole range is nops still covers them: they are reachable code. */
+  @Test
+  public void trapCoveringOnlyNopsIsKept() {
+    Body body =
+        convert(
+            "TrapCoversOnlyNops",
+            2,
+            b -> {
+              b.addLabel("try");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("end");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("handler");
+              b.addInstruction(new BuilderInstruction11x(Opcode.MOVE_EXCEPTION, 1));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addCatch(
+                  new ImmutableTypeReference("Ljava/lang/Exception;"),
+                  b.getLabel("try"),
+                  b.getLabel("end"),
+                  b.getLabel("handler"));
+            });
+
+    assertEquals(
+        List.of("nop", "nop", "return", "$u1 := @caughtexception", "return"), stmtsOf(body));
+    assertEquals(1, trapsOf(body).size());
+    assertEquals("nop", trapsOf(body).get(0).getBeginStmt().toString());
+  }
+
+  /** A trap that reaches the end of the body, with the padding nops behind its last Stmt. */
+  @Test
+  public void trapReachingTheEndOfTheBodyWithTrailingNops() {
+    Body body =
+        convert(
+            "TrapToEndOfBody",
+            2,
+            b -> {
+              b.addLabel("try");
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("out")));
+              b.addLabel("handler");
+              b.addInstruction(new BuilderInstruction11x(Opcode.MOVE_EXCEPTION, 1));
+              b.addLabel("out");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("end");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addCatch(
+                  new ImmutableTypeReference("Ljava/lang/Exception;"),
+                  b.getLabel("try"),
+                  b.getLabel("end"),
+                  b.getLabel("handler"));
+            });
+
+    // addTraps() answers a Trap that ends on a nop by inserting a caught exception Stmt of its own
+    // and ending the Trap there, so the body holds that Stmt next to the move-exception it covers
+    assertEquals(
+        List.of("$u0 = 0", "goto", "r0 := @caughtexception", "$u1 := @caughtexception", "return"),
+        stmtsOf(body));
+    assertEquals(1, trapsOf(body).size());
+  }
+
+  /** An endless loop, which is a body without any return at all. */
+  @Test
+  public void endlessLoopWithoutAReturn() {
+    Body body =
+        convert(
+            "EndlessLoop",
+            1,
+            b -> {
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("l")));
+            });
+
+    assertEquals(List.of("goto"), stmtsOf(body));
+  }
+
+  /** A throw behind which the padding nops sit. */
+  @Test
+  public void nopsBehindAThrow() {
+    Body body =
+        convert(
+            "NopsBehindThrow",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction11x(Opcode.THROW, 0));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+            });
+
+    assertEquals(List.of("$u0 = 0", "throw $u0"), stmtsOf(body));
+  }
+
+  /** Unreachable code that is not a nop is legal in dex too, and goes the same way. */
+  @Test
+  public void unreachableCodeThatIsNotANopIsDropped() {
+    Body body =
+        convert(
+            "UnreachableCode",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 3));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("goto", "return"), stmtsOf(body));
+  }
+
+  /**
+   * A nop that flow reaches and that ends the body means control runs off the end of the method.
+   * Dalvik's verifier rejects that, so no compiler or obfuscator emits it, and the frontend cannot
+   * express it either: the nop falls through to a block that does not exist. Dropping the nop would
+   * only hand the same fallthrough to the Stmt in front of it, which is what the frontend used to
+   * do - it reported the very same failure, naming {@code $u0 = 0} instead of the nop.
+   */
+  @Test
+  public void reachableTrailingNopRunsOffTheEndOfTheBody() {
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                convert(
+                    "ReachableTrailingNop",
+                    1,
+                    b -> {
+                      b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+                      b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+                    }));
+
+    assertTrue(
+        messagesOf(e).stream().anyMatch(m -> m.contains("falls into the abyss")),
+        messagesOf(e).toString());
+  }
+
+  /** The same where the nop is both the fallthrough and the target of an if. */
+  @Test
+  public void ifFallingIntoATrailingNopRunsOffTheEndOfTheBody() {
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                convert(
+                    "IfIntoTrailingNop",
+                    1,
+                    b -> {
+                      b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+                      b.addInstruction(
+                          new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+                      b.addLabel("l");
+                      b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+                    }));
+
+    assertTrue(
+        messagesOf(e).stream().anyMatch(m -> m.contains("falls into the abyss")),
+        messagesOf(e).toString());
+  }
+
+  /** Every message along the cause chain, so a test can look for the one it cares about. */
+  private static List<String> messagesOf(Throwable throwable) {
+    List<String> messages = new ArrayList<>();
+    for (Throwable t = throwable; t != null; t = t.getCause()) {
+      messages.add(String.valueOf(t.getMessage()));
+    }
+    return messages;
+  }
+}

--- a/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/typeresolving/TypeCheckerCycleTest.java
+++ b/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/typeresolving/TypeCheckerCycleTest.java
@@ -20,10 +20,10 @@ import sootup.jimple.frontend.JimpleStringAnalysisInputLocation;
 public class TypeCheckerCycleTest {
 
   @Test
-  @Timeout(
-      value = 500,
-      unit = TimeUnit.MILLISECONDS,
-      threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  // Only guards against the infinite loop this test was written for, so it is deliberately far
+  // above the real runtime (a few ms): a tighter bound just flakes when the machine is busy or the
+  // ANTLR lexer is still warming up.
+  @Timeout(value = 3, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   public void testWorklistLoopExplicitly() {
     JavaView view = getCycleView();
     MethodSignature signature =


### PR DESCRIPTION
**What does this PR address? (Why)**

`DexBody` converts the dex instruction list linearly, so every instruction becomes a `Stmt` whether or not control can reach it. Dalvik allows plenty that cannot be: the `nop` padding a switch or fill-array-data payload to a 4-byte boundary, and anything an obfuscator parks behind a `goto`. Those Stmts end up in blocks nothing points at, and `Body.build` rejects the graph:

```
Stmt 'nop' which is neither the StartingStmt nor a TrapHandler is missing a predecessor!
```

1601 of 6463 classes in one obfuscated APK failed to load. The JVM frontend never hits this because it converts along the flow and never visits an unreachable instruction.

**What are the main implementation details? (What, How)**

Two changes, neither sufficient alone:

1. **A `Stmt` that does not fall through ends its block.** `blockEnd` previously held only branching Stmts, so a `return` was chained to whatever followed it and inherited its block's fall-through edge (`return: must have '0' outgoing flow but has '1'`). Dead code now lands in its own block instead of hiding inside a live one.

2. **`removeUnreachableBlocks`**  a worklist from the entry block over fall-through and branch edges. A handler is marked once any block in its trap's range is, which can open new flow, so the two alternate to a fixpoint. Unreachable blocks are dropped along with their `successorMap` entries; traps are dropped when their begin or handler is gone, and their end advanced when only that was removed.

Reachability is the criterion, not the specific opcode.

Measured over 7 APKs: 280,314 bodies convert, 0 failures.

**Linked issue (if any)**

<!-- closes #<issue-number> -->

**Checklist**

*Code style & guidelines*
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments
- [x] I provided meaningful tests for my proposed change
- [ ] I updated documentation (if needed)

*Self-review*
- [x] I performed a self-review of my code
- [x] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [x] My branch is up to date with `develop`

*Review*
- [ ] CI checks are green
- [ ] I requested a review from a core contributor
