### PR TITLE
Exception handler merge corruption effecting Dex bodies

### DIFF
--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
@@ -378,10 +378,138 @@ public class DexBody {
     if (!currentList.isEmpty()) {
       listList.add(currentList);
     }
+    removeUnreachableBlocks(listList, branchingStmtListMap);
     graph.initializeWith(listList, branchingStmtListMap, traps);
     DexMethodSource dexMethodSource =
         new DexMethodSource(locals, methodSignature, graph, method, bodyInterceptors, view);
     return dexMethodSource.makeSootMethod();
+  }
+
+  private void removeUnreachableBlocks(
+      List<List<Stmt>> blocks, Map<BranchingStmt, List<Stmt>> successorMap) {
+    if (blocks.isEmpty()) {
+      return;
+    }
+
+    Map<Stmt, Integer> blockOfHead = new IdentityHashMap<>();
+    for (int i = 0; i < blocks.size(); i++) {
+      blockOfHead.put(blocks.get(i).get(0), i);
+    }
+
+    boolean[] reachable = new boolean[blocks.size()];
+    Deque<Integer> worklist = new ArrayDeque<>();
+    reachable[0] = true;
+    worklist.add(0);
+    // A handler is entered by an exceptional edge from the Stmts its Trap covers, so it becomes
+    // reachable as soon as any block of that range is.
+    boolean foundHandler = true;
+    while (foundHandler) {
+      followEdges(blocks, successorMap, blockOfHead, reachable, worklist);
+      foundHandler = false;
+      for (Trap trap : traps) {
+        Integer handler = blockOfHead.get(trap.getHandlerStmt());
+        if (handler != null
+            && !reachable[handler]
+            && isRangeReachable(trap, blockOfHead, reachable, blocks.size())) {
+          markReachable(handler, reachable, worklist);
+          foundHandler = true;
+        }
+      }
+    }
+
+    Set<Stmt> removedStmts = Collections.newSetFromMap(new IdentityHashMap<>());
+    for (int i = 0; i < blocks.size(); i++) {
+      if (!reachable[i]) {
+        removedStmts.addAll(blocks.get(i));
+      }
+    }
+    if (removedStmts.isEmpty()) {
+      return;
+    }
+
+    List<Trap> keptTraps = new ArrayList<>(traps.size());
+    for (Trap trap : traps) {
+      if (removedStmts.contains(trap.getBeginStmt())
+          || removedStmts.contains(trap.getHandlerStmt())) {
+        // nothing is left of the covered range, or of the handler that would catch for it
+        continue;
+      }
+      Stmt end = trap.getEndStmt();
+      if (removedStmts.contains(end)) {
+        // the end is exclusive, so with the Stmt behind the range gone, the range grows up to the
+        // next block that stayed; a range that would reach the end of the body cannot be expressed
+        end = null;
+        Integer endIndex = blockOfHead.get(trap.getEndStmt());
+        for (int i = endIndex == null ? blocks.size() : endIndex + 1; i < blocks.size(); i++) {
+          if (reachable[i]) {
+            end = blocks.get(i).get(0);
+            break;
+          }
+        }
+        if (end == null || end == trap.getBeginStmt()) {
+          continue;
+        }
+      }
+      keptTraps.add(
+          end == trap.getEndStmt()
+              ? trap
+              : Jimple.newTrap(
+                  trap.getExceptionType(), trap.getBeginStmt(), end, trap.getHandlerStmt()));
+    }
+    traps.clear();
+    traps.addAll(keptTraps);
+
+    successorMap.keySet().removeIf(removedStmts::contains);
+    stmtList.removeIf(removedStmts::contains);
+    blocks.removeIf(block -> removedStmts.contains(block.get(0)));
+  }
+
+  private static void followEdges(
+      List<List<Stmt>> blocks,
+      Map<BranchingStmt, List<Stmt>> successorMap,
+      Map<Stmt, Integer> blockOfHead,
+      boolean[] reachable,
+      Deque<Integer> worklist) {
+    while (!worklist.isEmpty()) {
+      int index = worklist.poll();
+      List<Stmt> block = blocks.get(index);
+      Stmt tail = block.get(block.size() - 1);
+      if (tail.fallsThrough()) {
+        markReachable(index + 1 < blocks.size() ? index + 1 : null, reachable, worklist);
+      }
+      if (tail.branches()) {
+        List<Stmt> targets = successorMap.get((BranchingStmt) tail);
+        if (targets != null) {
+          for (Stmt target : targets) {
+            markReachable(blockOfHead.get(target), reachable, worklist);
+          }
+        }
+      }
+    }
+  }
+
+  private static boolean isRangeReachable(
+      Trap trap, Map<Stmt, Integer> blockOfHead, boolean[] reachable, int blockCount) {
+    Integer begin = blockOfHead.get(trap.getBeginStmt());
+    if (begin == null) {
+      return false;
+    }
+    Integer end = blockOfHead.get(trap.getEndStmt());
+    // end is exclusive.
+    for (int i = begin, last = end == null ? blockCount : end; i < last; i++) {
+      if (reachable[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void markReachable(
+      @Nullable Integer blockIndex, boolean[] reachable, Deque<Integer> worklist) {
+    if (blockIndex != null && !reachable[blockIndex]) {
+      reachable[blockIndex] = true;
+      worklist.add(blockIndex);
+    }
   }
 
   // Just a conversion code from LinkedListMultimap<BranchingStmt, List<Stmt>> to Map<BranchingStmt,

--- a/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
+++ b/sootup.apk.frontend/src/main/java/sootup/apk/frontend/main/DexBody.java
@@ -34,6 +34,7 @@ import org.jf.dexlib2.immutable.debug.ImmutableLineNumber;
 import org.jf.dexlib2.immutable.debug.ImmutableRestartLocal;
 import org.jf.dexlib2.immutable.debug.ImmutableStartLocal;
 import org.jf.dexlib2.util.MethodUtil;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sootup.apk.frontend.Util.DexUtil;
@@ -327,9 +328,6 @@ public class DexBody {
     jimplify();
     // All the statements are converted, it is time to create a mutable statement graph
     MutableBlockControlFlowGraph graph = new MutableBlockControlFlowGraph();
-    // If the Nop Statements are not removed, graph.initializeWith throws a runtime exception
-    // It is only for the case where there is a JNop Statement after the return statement. Crazy
-    // android code :(
     MethodSignature methodSignature =
         view.getIdentifierFactory()
             .getMethodSignature(
@@ -337,10 +335,6 @@ public class DexBody {
                 method.getName(),
                 DexUtil.toSootType(method.getReturnType(), 0),
                 parameterTypes);
-    while (stmtList.get(stmtList.size() - 1) instanceof JNopStmt) {
-      stmtList.remove(stmtList.size() - 1);
-    }
-    //    stmtList.removeIf(JNopStmt.class::isInstance);
     Map<BranchingStmt, List<Stmt>> branchingStmtListMap = convertMultimap(branchingMap);
     Set<Stmt> blockBegin = new HashSet<>();
     Set<Stmt> blockEnd = new HashSet<>();
@@ -356,6 +350,14 @@ public class DexBody {
           blockBegin.add(trap.getEndStmt());
           blockBegin.add(trap.getHandlerStmt());
         });
+
+    // A Stmt that does not fall through - a return, a throw, a goto - ends its block. Whatever dex
+    // placed behind it is only reachable by a jump and must not be chained onto it.
+    for (Stmt stmt : stmtList) {
+      if (!stmt.fallsThrough()) {
+        blockEnd.add(stmt);
+      }
+    }
 
     List<List<Stmt>> listList = new ArrayList<>();
     List<Stmt> currentList = new ArrayList<>();

--- a/sootup.apk.frontend/src/test/java/sootup/apk/frontend/DexBodyEdgeCaseTest.java
+++ b/sootup.apk.frontend/src/test/java/sootup/apk/frontend/DexBodyEdgeCaseTest.java
@@ -1,0 +1,571 @@
+package sootup.apk.frontend;
+
+/*-
+ * #%L
+ * SootUp
+ * %%
+ * Copyright (C) 2022 - 2024 Kadiray Karakaya, Markus Schmidt, Jonas Klauke, Stefan Schott, Palaniappan Muthuraman, Marcus Hüwe and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.jf.dexlib2.AccessFlags;
+import org.jf.dexlib2.Opcode;
+import org.jf.dexlib2.Opcodes;
+import org.jf.dexlib2.builder.MethodImplementationBuilder;
+import org.jf.dexlib2.builder.SwitchLabelElement;
+import org.jf.dexlib2.builder.instruction.BuilderArrayPayload;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction10t;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction10x;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction11n;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction11x;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction21t;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction22c;
+import org.jf.dexlib2.builder.instruction.BuilderInstruction31t;
+import org.jf.dexlib2.builder.instruction.BuilderPackedSwitchPayload;
+import org.jf.dexlib2.builder.instruction.BuilderSparseSwitchPayload;
+import org.jf.dexlib2.immutable.ImmutableClassDef;
+import org.jf.dexlib2.immutable.ImmutableDexFile;
+import org.jf.dexlib2.immutable.ImmutableMethod;
+import org.jf.dexlib2.immutable.reference.ImmutableTypeReference;
+import org.jf.dexlib2.writer.pool.DexPool;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import sootup.apk.frontend.main.AndroidVersionInfo;
+import sootup.core.jimple.common.Trap;
+import sootup.core.model.Body;
+import sootup.core.util.printer.BriefStmtPrinter;
+import sootup.java.core.views.JavaView;
+
+/**
+ * Converts hand-built dex bodies that are legal for Dalvik but unusual for a Java compiler, to pin
+ * down what the frontend makes of them.
+ *
+ * <p>The bodies are assembled with dexlib2 and written to a bare {@code .dex} file instead of an
+ * APK, which the frontend accepts and which keeps every case readable next to its assertion. Most
+ * of them are about {@code nop}: dex has that instruction and needs it to pad the payload of a
+ * switch or of fill-array-data to a four byte boundary, so nops turn up in ordinary compiler output
+ * and anywhere an obfuscator wants to move code around.
+ *
+ * <p>The line the frontend draws is reachability, not the opcode: a Stmt that flow can arrive at
+ * stays in the Jimple, a nop as much as anything else, and only what nothing reaches is dropped -
+ * it cannot be expressed in a ControlFlowGraph that {@code Body.build} accepts. So each case below
+ * says both which Stmts survive and, where it matters, that a reachable nop is among them.
+ */
+public class DexBodyEdgeCaseTest {
+
+  @TempDir static Path tempDir;
+
+  /**
+   * Builds a dex holding one static {@code void run()} with the given instructions and loads it.
+   */
+  private static Body convert(
+      String name, int registerCount, Consumer<MethodImplementationBuilder> instructions) {
+    String descriptor = "Ldex/" + name + ";";
+    MethodImplementationBuilder builder = new MethodImplementationBuilder(registerCount);
+    instructions.accept(builder);
+    ImmutableMethod method =
+        new ImmutableMethod(
+            descriptor,
+            "run",
+            ImmutableList.of(),
+            "V",
+            AccessFlags.PUBLIC.getValue() | AccessFlags.STATIC.getValue(),
+            null,
+            null,
+            builder.getMethodImplementation());
+    ImmutableClassDef classDef =
+        new ImmutableClassDef(
+            descriptor,
+            AccessFlags.PUBLIC.getValue(),
+            "Ljava/lang/Object;",
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(method),
+            null);
+
+    Path dex = tempDir.resolve(name + ".dex");
+    try {
+      DexPool.writeTo(dex.toString(), new ImmutableDexFile(Opcodes.forApi(15), List.of(classDef)));
+    } catch (IOException e) {
+      throw new IllegalStateException("could not write " + dex, e);
+    }
+
+    JavaView view =
+        new JavaView(
+            List.of(
+                new ApkAnalysisInputLocation(
+                    dex,
+                    new AndroidVersionInfo(dex, ""),
+                    DexBodyInterceptors.Default.bodyInterceptors())));
+    return view.getMethod(
+            view.getIdentifierFactory()
+                .getMethodSignature(
+                    view.getIdentifierFactory().getClassType("dex." + name),
+                    "run",
+                    "void",
+                    List.of()))
+        .get()
+        .getBody();
+  }
+
+  private static List<String> stmtsOf(Body body) {
+    return body.getStmts().stream().map(Object::toString).collect(Collectors.toList());
+  }
+
+  private static List<Trap> trapsOf(Body body) {
+    return new BriefStmtPrinter(body.getControlFlowGraph()).getTraps();
+  }
+
+  /**
+   * {@code goto} does not fall through, so a nop behind it heads a block that nothing branches to.
+   * This is the shape that obfuscated APKs are full of.
+   */
+  @Test
+  public void unreachableNopBehindGotoIsDropped() {
+    Body body =
+        convert(
+            "NopBehindGoto",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("goto", "return"), stmtsOf(body));
+  }
+
+  /**
+   * A nop between a {@code return} and a branch target. The return does not fall through, so the
+   * nop is dead, but it sits at the tail of the return's block and carries the fallthrough edge
+   * into the target's block. A {@code NopEliminator} run over the built graph cannot repair this
+   * one: {@code removeNode(nop, keepFlow=true)} leaves the block's successor edge in place, and it
+   * then hangs off the {@code return}.
+   */
+  @Test
+  public void unreachableNopBehindReturnIsDropped() {
+    Body body =
+        convert(
+            "NopBehindReturn",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("$u0 = 0", "if $u0 == 0", "return", "return"), stmtsOf(body));
+  }
+
+  /** A nop that is a jump target is reached by that jump, so it stays and keeps the jump. */
+  @Test
+  public void nopThatIsABranchTargetIsKept() {
+    Body body =
+        convert(
+            "BranchToANop",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 1));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(
+        List.of("$u0 = 0", "if $u0 == 0", "return", "nop", "nop", "$u0 = 1", "return"),
+        stmtsOf(body));
+    // the second successor of the if is the branch target, which is the first of the two nops
+    assertEquals(
+        "nop", body.getControlFlowGraph().successors(body.getStmts().get(1)).get(1).toString());
+  }
+
+  /** The same for a backwards jump, which makes the nop the head of the loop body. */
+  @Test
+  public void nopThatIsABackwardsBranchTargetIsKept() {
+    Body body =
+        convert(
+            "BackwardsBranchToANop",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("$u0 = 0", "nop", "if $u0 == 0", "return"), stmtsOf(body));
+    assertEquals(
+        "nop", body.getControlFlowGraph().successors(body.getStmts().get(2)).get(1).toString());
+  }
+
+  /** Nops behind the last Stmt of the body - the only case the frontend used to handle. */
+  @Test
+  public void trailingNopsAreDropped() {
+    Body body =
+        convert(
+            "TrailingNops",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+            });
+
+    assertEquals(List.of("return"), stmtsOf(body));
+  }
+
+  /** A nop as the entry instruction is the reachable Stmt of the method, and stays its head. */
+  @Test
+  public void leadingNopIsKeptAsTheStartingStmt() {
+    Body body =
+        convert(
+            "LeadingNop",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("nop", "$u0 = 0", "return"), stmtsOf(body));
+    assertEquals("nop", body.getControlFlowGraph().getStartingStmt().toString());
+  }
+
+  /** A body that is nothing but nops and a return: every one of them is on the path. */
+  @Test
+  public void bodyOfOnlyNopsIsKept() {
+    Body body =
+        convert(
+            "OnlyNops",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("nop", "nop", "nop", "return"), stmtsOf(body));
+  }
+
+  /**
+   * The reason nops exist in compiler output: a packed-switch payload has to start on a four byte
+   * boundary, so dx/d8 pads with a nop whenever the preceding code has an odd number of code units.
+   */
+  @Test
+  public void alignmentNopBeforeAPackedSwitchPayload() {
+    Body body =
+        convert(
+            "PackedSwitchPadding",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 1));
+              b.addInstruction(
+                  new BuilderInstruction31t(Opcode.PACKED_SWITCH, 0, b.getLabel("payload")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("case0");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("case1");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("payload");
+              b.addInstruction(
+                  new BuilderPackedSwitchPayload(
+                      0, List.of(b.getLabel("case0"), b.getLabel("case1"))));
+            });
+
+    assertEquals(
+        List.of(
+            "$u0 = 1",
+            "switch($u0) {     case 0:     case 1:     default:  }",
+            "return",
+            "return",
+            "return"),
+        stmtsOf(body));
+  }
+
+  /** The same for a sparse-switch payload. */
+  @Test
+  public void alignmentNopBeforeASparseSwitchPayload() {
+    Body body =
+        convert(
+            "SparseSwitchPadding",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 1));
+              b.addInstruction(
+                  new BuilderInstruction31t(Opcode.SPARSE_SWITCH, 0, b.getLabel("payload")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("case7");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("payload");
+              b.addInstruction(
+                  new BuilderSparseSwitchPayload(
+                      List.of(new SwitchLabelElement(7, b.getLabel("case7")))));
+            });
+
+    assertTrue(
+        stmtsOf(body).stream().anyMatch(stmt -> stmt.startsWith("switch")),
+        stmtsOf(body).toString());
+    assertTrue(stmtsOf(body).stream().noneMatch("nop"::equals), stmtsOf(body).toString());
+  }
+
+  /**
+   * fill-array-data with an empty payload is the one place where the frontend itself emits a nop.
+   */
+  @Test
+  public void emptyArrayPayload() {
+    Body body =
+        convert(
+            "EmptyArrayPayload",
+            2,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(
+                  new BuilderInstruction22c(
+                      Opcode.NEW_ARRAY, 1, 0, new ImmutableTypeReference("[I")));
+              b.addInstruction(
+                  new BuilderInstruction31t(Opcode.FILL_ARRAY_DATA, 1, b.getLabel("data")));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("data");
+              b.addInstruction(new BuilderArrayPayload(4, List.of()));
+            });
+
+    assertEquals(List.of("$u0 = 0", "$u1 = newarray (int)[$u0]", "nop", "return"), stmtsOf(body));
+  }
+
+  /** A try block that starts on a nop keeps that nop, and with it its range. */
+  @Test
+  public void trapBeginningOnANopKeepsItsRange() {
+    Body body =
+        convert(
+            "TrapBeginsOnNop",
+            2,
+            b -> {
+              b.addLabel("try");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addLabel("end");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("handler");
+              b.addInstruction(new BuilderInstruction11x(Opcode.MOVE_EXCEPTION, 1));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addCatch(
+                  new ImmutableTypeReference("Ljava/lang/Exception;"),
+                  b.getLabel("try"),
+                  b.getLabel("end"),
+                  b.getLabel("handler"));
+            });
+
+    assertEquals(
+        List.of("nop", "$u0 = 0", "return", "$u1 := @caughtexception", "return"), stmtsOf(body));
+    assertEquals(1, trapsOf(body).size());
+    assertEquals("nop", trapsOf(body).get(0).getBeginStmt().toString());
+  }
+
+  /** A try block whose whole range is nops still covers them: they are reachable code. */
+  @Test
+  public void trapCoveringOnlyNopsIsKept() {
+    Body body =
+        convert(
+            "TrapCoversOnlyNops",
+            2,
+            b -> {
+              b.addLabel("try");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addLabel("end");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("handler");
+              b.addInstruction(new BuilderInstruction11x(Opcode.MOVE_EXCEPTION, 1));
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addCatch(
+                  new ImmutableTypeReference("Ljava/lang/Exception;"),
+                  b.getLabel("try"),
+                  b.getLabel("end"),
+                  b.getLabel("handler"));
+            });
+
+    assertEquals(
+        List.of("nop", "nop", "return", "$u1 := @caughtexception", "return"), stmtsOf(body));
+    assertEquals(1, trapsOf(body).size());
+    assertEquals("nop", trapsOf(body).get(0).getBeginStmt().toString());
+  }
+
+  /** A trap that reaches the end of the body, with the padding nops behind its last Stmt. */
+  @Test
+  public void trapReachingTheEndOfTheBodyWithTrailingNops() {
+    Body body =
+        convert(
+            "TrapToEndOfBody",
+            2,
+            b -> {
+              b.addLabel("try");
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("out")));
+              b.addLabel("handler");
+              b.addInstruction(new BuilderInstruction11x(Opcode.MOVE_EXCEPTION, 1));
+              b.addLabel("out");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+              b.addLabel("end");
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+              b.addCatch(
+                  new ImmutableTypeReference("Ljava/lang/Exception;"),
+                  b.getLabel("try"),
+                  b.getLabel("end"),
+                  b.getLabel("handler"));
+            });
+
+    // addTraps() answers a Trap that ends on a nop by inserting a caught exception Stmt of its own
+    // and ending the Trap there, so the body holds that Stmt next to the move-exception it covers
+    assertEquals(
+        List.of("$u0 = 0", "goto", "r0 := @caughtexception", "$u1 := @caughtexception", "return"),
+        stmtsOf(body));
+    assertEquals(1, trapsOf(body).size());
+  }
+
+  /** An endless loop, which is a body without any return at all. */
+  @Test
+  public void endlessLoopWithoutAReturn() {
+    Body body =
+        convert(
+            "EndlessLoop",
+            1,
+            b -> {
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("l")));
+            });
+
+    assertEquals(List.of("goto"), stmtsOf(body));
+  }
+
+  /** A throw behind which the padding nops sit. */
+  @Test
+  public void nopsBehindAThrow() {
+    Body body =
+        convert(
+            "NopsBehindThrow",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+              b.addInstruction(new BuilderInstruction11x(Opcode.THROW, 0));
+              b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+            });
+
+    assertEquals(List.of("$u0 = 0", "throw $u0"), stmtsOf(body));
+  }
+
+  /** Unreachable code that is not a nop is legal in dex too, and goes the same way. */
+  @Test
+  public void unreachableCodeThatIsNotANopIsDropped() {
+    Body body =
+        convert(
+            "UnreachableCode",
+            1,
+            b -> {
+              b.addInstruction(new BuilderInstruction10t(Opcode.GOTO, b.getLabel("l")));
+              b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 3));
+              b.addLabel("l");
+              b.addInstruction(new BuilderInstruction10x(Opcode.RETURN_VOID));
+            });
+
+    assertEquals(List.of("goto", "return"), stmtsOf(body));
+  }
+
+  /**
+   * A nop that flow reaches and that ends the body means control runs off the end of the method.
+   * Dalvik's verifier rejects that, so no compiler or obfuscator emits it, and the frontend cannot
+   * express it either: the nop falls through to a block that does not exist. Dropping the nop would
+   * only hand the same fallthrough to the Stmt in front of it, which is what the frontend used to
+   * do - it reported the very same failure, naming {@code $u0 = 0} instead of the nop.
+   */
+  @Test
+  public void reachableTrailingNopRunsOffTheEndOfTheBody() {
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                convert(
+                    "ReachableTrailingNop",
+                    1,
+                    b -> {
+                      b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+                      b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+                    }));
+
+    assertTrue(
+        messagesOf(e).stream().anyMatch(m -> m.contains("falls into the abyss")),
+        messagesOf(e).toString());
+  }
+
+  /** The same where the nop is both the fallthrough and the target of an if. */
+  @Test
+  public void ifFallingIntoATrailingNopRunsOffTheEndOfTheBody() {
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                convert(
+                    "IfIntoTrailingNop",
+                    1,
+                    b -> {
+                      b.addInstruction(new BuilderInstruction11n(Opcode.CONST_4, 0, 0));
+                      b.addInstruction(
+                          new BuilderInstruction21t(Opcode.IF_EQZ, 0, b.getLabel("l")));
+                      b.addLabel("l");
+                      b.addInstruction(new BuilderInstruction10x(Opcode.NOP));
+                    }));
+
+    assertTrue(
+        messagesOf(e).stream().anyMatch(m -> m.contains("falls into the abyss")),
+        messagesOf(e).toString());
+  }
+
+  /** Every message along the cause chain, so a test can look for the one it cares about. */
+  private static List<String> messagesOf(Throwable throwable) {
+    List<String> messages = new ArrayList<>();
+    for (Throwable t = throwable; t != null; t = t.getCause()) {
+      messages.add(String.valueOf(t.getMessage()));
+    }
+    return messages;
+  }
+}

--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockControlFlowGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockControlFlowGraph.java
@@ -817,11 +817,11 @@ public class MutableBlockControlFlowGraph extends MutableControlFlowGraph {
         addNodeToBlock(firstBlock, stmt);
       }
 
-      // i.e. can just be the single followingblock which we merge now
+      // i.e. can just be the single following block which we merge now
       firstBlock.clearSuccessorBlocks();
 
       // update linking info into firstBlock
-      // done in clearPredecessorBlock      firstBlock.removeSuccessorBlock(followingBlock);
+      // done in clearPredecessorBlock firstBlock.removeSuccessorBlock(followingBlock);
       List<MutableBasicBlock> successors = followingBlock.getSuccessors();
       for (int i = 0; i < successors.size(); i++) {
         MutableBasicBlock succ = successors.get(i);

--- a/sootup.core/src/main/java/sootup/core/graph/MutableBlockControlFlowGraph.java
+++ b/sootup.core/src/main/java/sootup/core/graph/MutableBlockControlFlowGraph.java
@@ -804,8 +804,23 @@ public class MutableBlockControlFlowGraph extends MutableControlFlowGraph {
         || (sBlockPredecessors.size() == 1 && sBlockPredecessors.get(0) != firstBlock)) {
       return false;
     }
+    // Merging a handler away leaves the catching blocks pointing at a dropped block.
+    if (isExceptionalSuccessor(followingBlock)) {
+      return false;
+    }
     // check if the same traps are applied to both blocks
     return firstBlock.getExceptionalSuccessors().equals(followingBlock.getExceptionalSuccessors());
+  }
+
+  private boolean isExceptionalSuccessor(@NonNull MutableBasicBlock block) {
+    for (MutableBasicBlock otherBlock : blocks) {
+      final Map<ClassType, MutableBasicBlock> exceptionalSuccessors =
+          otherBlock.getExceptionalSuccessors();
+      if (!exceptionalSuccessors.isEmpty() && exceptionalSuccessors.containsValue(block)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** trys to merge the second block into the first one if possible */
@@ -1146,11 +1161,29 @@ public class MutableBlockControlFlowGraph extends MutableControlFlowGraph {
     final MutableBasicBlock newBlock = addBlockInternal(stmts, exceptionMap);
     // insert before a existingStmt that is at the beginning of a Block
     if (oldBlock.getHead() == existingStmt) {
+      // Exceptional edges enter oldBlock too, so they are re-pointed as well; predecessorBlocks
+      // holds one untagged entry per edge, so count moves the entries.
+      Set<MutableBasicBlock> movedPredecessors = Collections.newSetFromMap(new IdentityHashMap<>());
       for (MutableBasicBlock predecessor : Lists.newArrayList(oldBlock.getPredecessors())) {
-        // cleanup old & add new link
-        predecessor.replaceSuccessorBlock(oldBlock, newBlock);
+        if (!movedPredecessors.add(predecessor)) {
+          continue;
+        }
+        int normalEdgeCount = predecessor.replaceSuccessorBlock(oldBlock, newBlock).size();
+        List<ClassType> exceptionalEdges = new ArrayList<>();
+        predecessor
+            .getExceptionalSuccessors()
+            .forEach(
+                (type, handler) -> {
+                  if (handler == oldBlock) {
+                    exceptionalEdges.add(type);
+                  }
+                });
         oldBlock.removePredecessorBlock(predecessor);
-        newBlock.addPredecessorBlock(predecessor);
+        for (int i = 0; i < normalEdgeCount; i++) {
+          newBlock.addPredecessorBlock(predecessor);
+        }
+        // re-points the edge and registers predecessor on newBlock for each exception type
+        exceptionalEdges.forEach(type -> predecessor.linkExceptionalSuccessorBlock(type, newBlock));
       }
       // try to merge inserted stmts into oldBlock
       if (!tryMergeBlocks(newBlock, oldBlock)) {

--- a/sootup.core/src/main/java/sootup/core/graph/ReversePostOrderBlockTraversal.java
+++ b/sootup.core/src/main/java/sootup/core/graph/ReversePostOrderBlockTraversal.java
@@ -48,7 +48,10 @@ public class ReversePostOrderBlockTraversal implements BlockTraversalStrategy {
   @Override
   @NonNull
   public List<BasicBlock<?>> getBlockTraversal() {
-    List<BasicBlock<?>> blocks = new ArrayList<>(this.cfg.getStmts().size());
+    // sizing this from getStmts() would walk the graph with the validating BlockGraphIterator,
+    // whose complaint about an unconnected graph is built from a DotExporter url that sorts the
+    // blocks again - which lands back here and recurses until the stack is gone
+    List<BasicBlock<?>> blocks = new ArrayList<>(this.cfg.getBlocks().size());
     new ReversePostOrderBlockTraversal(this.cfg).iterator().forEachRemaining(blocks::add);
     return blocks;
   }

--- a/sootup.core/src/test/java/sootup/core/graph/MutableBlockControlFlowGraphTest.java
+++ b/sootup.core/src/test/java/sootup/core/graph/MutableBlockControlFlowGraphTest.java
@@ -1158,4 +1158,70 @@ public class MutableBlockControlFlowGraphTest {
     assertTrue(entrypoints.contains(handlerStmt1));
     assertTrue(entrypoints.contains(handlerStmt2));
   }
+
+  /** Inserting before a Trap handler must not strand its exceptional edges on a dropped block. */
+  @Test
+  public void insertBeforeAHandlerKeepsExceptionalEdgesOnALiveBlock() {
+    MutableBlockControlFlowGraph graph = new MutableBlockControlFlowGraph();
+
+    JNopStmt handlerHead = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+    JNopStmt handlerTail = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+    JNopStmt thrower = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+    JNopStmt inserted = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+
+    graph.addBlock(Arrays.asList(handlerHead, handlerTail), Collections.emptyMap());
+    // an exceptional edge into the handler, no normal one
+    graph.addBlock(
+        Collections.singletonList(thrower), Collections.singletonMap(ioExceptionSig, handlerHead));
+    graph.setStartingStmt(thrower);
+    // and an ordinary path into the same handler head
+    graph.putEdge(firstNop, handlerHead);
+
+    graph.insertBefore(handlerHead, inserted);
+
+    assertExceptionalEdgesPointAtLiveBlocks(graph);
+  }
+
+  /** The same for a handler nothing reaches by ordinary flow: the inserted Stmt must still run. */
+  @Test
+  public void insertBeforeAHandlerReachedOnlyExceptionallyKeepsTheInsertedStmtReachable() {
+    MutableBlockControlFlowGraph graph = new MutableBlockControlFlowGraph();
+
+    JNopStmt handlerHead = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+    JNopStmt handlerTail = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+    JNopStmt thrower = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+    JNopStmt inserted = new JNopStmt(StmtPositionInfo.getNoStmtPositionInfo());
+
+    graph.addBlock(Arrays.asList(handlerHead, handlerTail), Collections.emptyMap());
+    graph.addBlock(
+        Collections.singletonList(thrower), Collections.singletonMap(ioExceptionSig, handlerHead));
+    graph.setStartingStmt(thrower);
+
+    graph.insertBefore(handlerHead, inserted);
+
+    assertExceptionalEdgesPointAtLiveBlocks(graph);
+
+    BasicBlock<?> insertedBlock = graph.getBlockOf(inserted);
+    boolean reached =
+        graph.getBlocks().stream()
+            .anyMatch(
+                b ->
+                    b != insertedBlock
+                        && (b.getSuccessors().contains(insertedBlock)
+                            || b.getExceptionalSuccessors().containsValue(insertedBlock)));
+    assertTrue(reached, "nothing reaches the inserted Stmt: " + inserted);
+  }
+
+  /** Every exceptional edge has to land on a block this graph still holds. */
+  private static void assertExceptionalEdgesPointAtLiveBlocks(MutableBlockControlFlowGraph graph) {
+    final Collection<? extends BasicBlock<?>> blocks = graph.getBlocks();
+    for (BasicBlock<?> block : blocks) {
+      for (BasicBlock<?> handler : block.getExceptionalSuccessors().values()) {
+        assertTrue(
+            blocks.contains(handler),
+            "an exceptional edge points at a block the graph does not hold anymore: "
+                + handler.getStmts());
+      }
+    }
+  }
 }

--- a/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/typeresolving/TypeCheckerCycleTest.java
+++ b/sootup.java.bytecode.frontend/src/test/java/sootup/java/bytecode/frontend/interceptors/typeresolving/TypeCheckerCycleTest.java
@@ -20,10 +20,10 @@ import sootup.jimple.frontend.JimpleStringAnalysisInputLocation;
 public class TypeCheckerCycleTest {
 
   @Test
-  @Timeout(
-      value = 500,
-      unit = TimeUnit.MILLISECONDS,
-      threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  // Only guards against the infinite loop this test was written for, so it is deliberately far
+  // above the real runtime (a few ms): a tighter bound just flakes when the machine is busy or the
+  // ANTLR lexer is still warming up.
+  @Timeout(value = 3, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   public void testWorklistLoopExplicitly() {
     JavaView view = getCycleView();
     MethodSignature signature =


### PR DESCRIPTION
 > Builds on #1728, this branch contains its commits, so review that one first. The changes here are confined to `sootup.core`.

  **What does this PR address? (Why)**

  `insertBefore` on the head of a Trap handler corrupts the graph. A block keeps one flat list of who points at it, and both normal and exceptional edges write to it. `insertBefore` moved *every* entry onto the inserted block, but `replaceSuccessorBlock` only rewrites the normal successor array; so an exceptional edge kept pointing at the old block while the entry recording it was deleted. The handler then looked unreachable and `tryMergeBlocks` merged it away, leaving the catching blocks pointing at a block `getBlocks()` no longer holds.

  `BlockGraphIterator` follows exceptional successors into that stale block and returns more blocks than the graph has:

  ```
  There are -3 Blocks that are not iterated! i.e. the ControlFlowGraph is not connected from its startingStmt!
  ```

  A negative count means a duplicated block, not a missing one.

  Reaching this needs a handler whose first `Stmt` is an ordinary one, a legal `insertBefore` target. That is common in dex and impossible on the JVM:

  - In Dalvik, `move-exception` is optional, it "must be the first instruction of any exception handler ***whose caught exception is not to be ignored***" ([Dalvik bytecode][dalvik], opcode `0d`). Ignore the exception and there is no `move-exception`; the handler simply starts executing.
  - On the JVM the exception is always handed to the handler on the operand stack, "the operand stack of the current frame is cleared, *objectref* is pushed back onto the operand stack, and execution continues" ([JVMS §6.5 `athrow`][athrow]); so the handler is forced to consume it with an `astore` or a `pop`.

  `AsmMethodSource` therefore always has something to model and always emits `@caughtexception`. `DexBody.addTraps` does not, and falls back to the handler instruction's own `Stmt`, logging `First instruction of trap handler unit not MoveException but ...`. Measured: **741 of 2795** traps in one APK and **1995 of 6110** in another have a handler that is not a `@caughtexception` `Stmt`. `BoomerangPreInterceptor` and `TypeAssigner` both insert before such heads.

The failure was also unreadable: building the exception message re-entered the failing iterator, so it surfaced as a `StackOverflowError` instead.

[dalvik]: https://source.android.com/docs/core/runtime/dalvik-bytecode
[athrow]: https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-6.html#jvms-6.5.athrow

**What are the main implementation details? (What, How)**

1. **`insertBefore`** re-points the exceptional edges onto the inserted block rather than abandoning them, everything that entered the old block must enter the inserted `Stmt`s, or they are unreachable. Predecessor entries are moved by count, since a predecessor can reach a block through several edges at once (two case labels of one switch, or a normal edge beside an exceptional one) and the entries are untagged.

2. **`isMergeable`** refuses to merge away a block an exceptional edge enters. `insertBefore` handles its own case, but `removeNode` and `tryMergeWithSuccessorBlock` reach `tryMergeBlocks` too, and there the caller cannot know whether `firstBlock`'s statements belong on the exceptional path. Merging is only a layout optimisation, so refusing costs one extra block.

Fix 1 alone left 1 and 3 failures on two APKs; both together, 0.

3. **`ReversePostOrderBlockTraversal`** sized its list with `cfg.getStmts()`, which walks the graph through the validating iterator. Sized from `getBlocks().size()` instead, so the real `IllegalStateException` surfaces rather than a `StackOverflowError`.

Two tests in `MutableBlockControlFlowGraphTest` cover a handler reached both exceptionally and normally, and one reached only exceptionally. Both fail on `develop` with `an exceptional edge points at a block the graph does not hold anymore`.

**Linked issue (if any)**

Builds on #1728.

**Checklist**

*Code style & guidelines*
- [x] I ran the formatter: `mvn com.spotify.fmt:fmt-maven-plugin:format`
- [x] I added the necessary comments in the code
- [x] I provided meaningful tests for my proposed change
- [ ] I updated documentation (if needed)

*Self-review*
- [x] I performed a self-review of my code
- [x] I added or updated tests where needed
- [x] I have successfully run tests with your changes locally
- [x] My branch is up to date with `develop`

*Review*
- [ ] CI checks are green
- [ ] I requested a review from a core contributor